### PR TITLE
dev: configure production deployment with tagged releases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
 
 name: Generalized Deployments
 jobs:
@@ -14,10 +16,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
       with:
         role-to-assume: ${{ secrets.GDBP_AWS_IAM_ROLE_ARN }}
         aws-region: us-west-2
+
+    - name: Override GITHUB_REF for tagged releases
+      run: echo "GITHUB_REF_OVERRIDE=refs/heads/production" >> $GITHUB_ENV
+      if: startsWith(github.ref, 'refs/tags/')
+
     - name: Generalized Deployments
       uses: brave-intl/general-docker-build-pipeline-action@50a99c1f051b1d8e20ed79ded2e69ab3153b66e4 # v1.0.25


### PR DESCRIPTION
This lets us avoid a dedicated `production` branch with a merge queue. At this stage, we're just two people in this project - one primary contributor (@onyb) and one reviewer (@Douglashdaniel). Using a merge queue will slow us down, since each deployment will require an additional PR approval from the reviewer.

In order to get the same benefits/protections of having a merge queue, I enabled the following settings for the repo:
- Require branches to be up to date before merging
- Require linear history