### PR TITLE
feat(pricing): add source to TokenPriceResponse

### DIFF
--- a/app/api/pricing/coingecko.py
+++ b/app/api/pricing/coingecko.py
@@ -13,6 +13,7 @@ from .models import (
     CoingeckoPlatform,
     TokenPriceRequest,
     TokenPriceResponse,
+    PriceSource,
 )
 
 
@@ -129,6 +130,7 @@ class CoinGeckoClient:
                     vs_currency=batch.vs_currency,
                     price=float(combined_data[id][batch.vs_currency.value.lower()]),
                     cache_status=CacheStatus.MISS,
+                    source=PriceSource.COINGECKO,
                 )
             except (KeyError, ValueError):
                 continue

--- a/app/api/pricing/jupiter.py
+++ b/app/api/pricing/jupiter.py
@@ -8,6 +8,7 @@ from .models import (
     TokenPriceResponse,
     CacheStatus,
     VsCurrency,
+    PriceSource,
 )
 from .cache import JupiterPriceCache
 from .coingecko import CoinGeckoClient
@@ -122,6 +123,7 @@ class JupiterClient:
                     vs_currency=batch.vs_currency,
                     price=price,
                     cache_status=CacheStatus.MISS,
+                    source=PriceSource.JUPITER,
                 )
                 jupiter_responses.append(item)
             except (KeyError, ValueError):

--- a/app/api/pricing/models.py
+++ b/app/api/pricing/models.py
@@ -21,6 +21,11 @@ class CacheStatus(str, Enum):
     MISS = "MISS"
 
 
+class PriceSource(str, Enum):
+    COINGECKO = "coingecko"
+    JUPITER = "jupiter"
+
+
 class TokenPriceRequest(BaseModel):
     coin_type: CoinType = Field(description=COIN_TYPE_DESCRIPTION)
     chain_id: ChainId | None = Field(default=None, description=CHAIN_ID_DESCRIPTION)
@@ -66,6 +71,7 @@ class TokenPriceResponse(TokenPriceRequest):
         default=VsCurrency.USD, description=VS_CURRENCY_DESCRIPTION
     )
     cache_status: CacheStatus
+    source: PriceSource = Field(description="Source of the price data")
 
     model_config = {
         "json_schema_extra": {
@@ -77,6 +83,7 @@ class TokenPriceResponse(TokenPriceRequest):
                     "vs_currency": VsCurrency.USD,
                     "price": 1.01,
                     "cache_status": CacheStatus.MISS,
+                    "source": PriceSource.COINGECKO,
                 }
             ]
         }

--- a/app/api/pricing/tests/test_cache.py
+++ b/app/api/pricing/tests/test_cache.py
@@ -10,6 +10,7 @@ from app.api.pricing.models import (
     CacheStatus,
     BatchTokenPriceRequests,
     VsCurrency,
+    PriceSource,
 )
 
 
@@ -61,6 +62,7 @@ async def test_coingecko_get_with_cached_values(mock_redis):
         price=1.01,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.COINGECKO,
     )
     eth_response = TokenPriceResponse(
         coin_type=CoinType.ETH,
@@ -69,12 +71,14 @@ async def test_coingecko_get_with_cached_values(mock_redis):
         price=2000.0,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.COINGECKO,
     )
     btc_response = TokenPriceResponse(
         coin_type=CoinType.BTC,
         price=50000.0,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.COINGECKO,
     )
 
     # Create cached data without cache_status
@@ -136,6 +140,7 @@ async def test_coingecko_get_with_mixed_cache_status(mock_redis):
         price=2000.0,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.COINGECKO,
     )
 
     # Create cached data without cache_status
@@ -172,12 +177,14 @@ async def test_coingecko_set_multiple_responses(mock_redis):
             price=2000.0,
             vs_currency=VsCurrency.USD,
             cache_status=CacheStatus.HIT,
+            source=PriceSource.COINGECKO,
         ),
         TokenPriceResponse(
             coin_type=CoinType.BTC,
             price=50000.0,
             vs_currency=VsCurrency.USD,
             cache_status=CacheStatus.HIT,
+            source=PriceSource.COINGECKO,
         ),
     ]
 
@@ -234,6 +241,7 @@ async def test_coingecko_set_with_custom_ttl(mock_redis):
         price=2000.0,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.COINGECKO,
     )
 
     # Mock pipeline
@@ -290,6 +298,7 @@ async def test_jupiter_get_with_cached_values(mock_redis):
         price=1.01,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.JUPITER,
     )
     usdt_response = TokenPriceResponse(
         coin_type=CoinType.SOL,
@@ -298,6 +307,7 @@ async def test_jupiter_get_with_cached_values(mock_redis):
         price=1.02,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.JUPITER,
     )
 
     # Create cached data without cache_status
@@ -363,6 +373,7 @@ async def test_jupiter_get_with_mixed_cache_status(mock_redis):
         price=1.01,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.JUPITER,
     )
 
     # Create cached data without cache_status
@@ -409,6 +420,7 @@ async def test_jupiter_set_multiple_responses(mock_redis):
             price=1.01,
             vs_currency=VsCurrency.USD,
             cache_status=CacheStatus.HIT,
+            source=PriceSource.JUPITER,
         ),
         TokenPriceResponse(
             coin_type=CoinType.SOL,
@@ -417,6 +429,7 @@ async def test_jupiter_set_multiple_responses(mock_redis):
             price=1.02,
             vs_currency=VsCurrency.USD,
             cache_status=CacheStatus.HIT,
+            source=PriceSource.JUPITER,
         ),
     ]
 
@@ -479,6 +492,7 @@ async def test_jupiter_set_with_custom_ttl(mock_redis):
         price=1.01,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.JUPITER,
     )
 
     # Mock pipeline
@@ -518,6 +532,7 @@ async def test_jupiter_cache_key_generation():
         price=1.02,
         vs_currency=VsCurrency.USD,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.JUPITER,
     )
 
     cache_key = JupiterPriceCache._get_cache_key(response, VsCurrency.USD)

--- a/app/api/pricing/tests/test_jupiter.py
+++ b/app/api/pricing/tests/test_jupiter.py
@@ -9,6 +9,7 @@ from app.api.pricing.models import (
     TokenPriceResponse,
     CacheStatus,
     VsCurrency,
+    PriceSource,
 )
 
 
@@ -87,6 +88,7 @@ async def test_get_prices_all_cached(client):
         vs_currency=VsCurrency.USD,
         price=1.0,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.JUPITER,
     )
 
     with patch("app.api.pricing.jupiter.JupiterPriceCache.get") as mock_cache:
@@ -209,6 +211,7 @@ async def test_get_prices_non_usd_currency(client, mock_httpx_client):
             vs_currency=VsCurrency.EUR,
             price=0.85,  # USDC price in EUR
             cache_status=CacheStatus.MISS,
+            source=PriceSource.COINGECKO,
         )
     ]
 
@@ -411,6 +414,7 @@ async def test_get_prices_mixed_cache_and_fetch(client, mock_httpx_client):
         vs_currency=VsCurrency.USD,
         price=1.0,
         cache_status=CacheStatus.HIT,
+        source=PriceSource.JUPITER,
     )
 
     # Batch to fetch

--- a/app/api/pricing/tests/test_routes.py
+++ b/app/api/pricing/tests/test_routes.py
@@ -10,6 +10,7 @@ from app.api.pricing.models import (
     CacheStatus,
     BatchTokenPriceRequests,
     TokenPriceRequest,
+    PriceSource,
 )
 
 from app.main import app
@@ -64,6 +65,7 @@ def test_get_price_success(client, mock_coingecko_client):
         vs_currency=VsCurrency.USD,
         price=1.01,
         cache_status=CacheStatus.MISS,
+        source=PriceSource.COINGECKO,
     )
     mock_coingecko_client.filter.return_value = (batch, empty_batch)
     mock_coingecko_client.get_prices.return_value = [expected_response]
@@ -147,12 +149,14 @@ def test_get_prices_success(client, mock_coingecko_client, mock_jupiter_client):
         vs_currency=VsCurrency.USD,
         price=1.01,
         cache_status=CacheStatus.MISS,
+        source=PriceSource.COINGECKO,
     )
     response_btc = TokenPriceResponse(
         coin_type=CoinType.BTC,
         vs_currency=VsCurrency.USD,
         price=50000.0,
         cache_status=CacheStatus.MISS,
+        source=PriceSource.COINGECKO,
     )
     response_sol = TokenPriceResponse(
         coin_type=CoinType.SOL,
@@ -161,6 +165,7 @@ def test_get_prices_success(client, mock_coingecko_client, mock_jupiter_client):
         vs_currency=VsCurrency.EUR,
         price=0.0000283013301,
         cache_status=CacheStatus.MISS,
+        source=PriceSource.JUPITER,
     )
     mock_coingecko_client.filter.return_value = (
         BatchTokenPriceRequests(
@@ -267,6 +272,7 @@ def test_get_price_cached_response(client):
             vs_currency=VsCurrency.USD,
             price=1.01,
             cache_status=CacheStatus.HIT,
+            source=PriceSource.COINGECKO,
         )
 
         # Mock the cache to return the cached response and an empty batch to fetch


### PR DESCRIPTION
We now return the source of the price in the response of `getPrices` endpoint.

**Example request:**

```bash
curl -X 'POST' \
  'http://127.0.0.1:8000/api/pricing/v1/getPrices?vs_currency=USD' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '[
  {
    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
    "chain_id": "0x1",
    "coin_type": "ETH"
  },
  {
    "coin_type": "ZEC"
  },
  {
    "address": "5rmx75XP4VkWcxYsmcLSRbbwzN8g2Cy4YDgBabvboop",
    "chain_id": "0x65",
    "coin_type": "SOL"
  }
]'
```

**Response:**

```json
[
  {
    "coin_type": "ETH",
    "chain_id": "0x1",
    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
    "price": 0.999789,
    "vs_currency": "USD",
    "cache_status": "HIT",
    "source": "coingecko"
  },
  {
    "coin_type": "ZEC",
    "chain_id": null,
    "address": null,
    "price": 41.6,
    "vs_currency": "USD",
    "cache_status": "HIT",
    "source": "coingecko"
  },
  {
    "coin_type": "SOL",
    "chain_id": "0x65",
    "address": "5rmx75XP4VkWcxYsmcLSRbbwzN8g2Cy4YDgBabvboop",
    "price": 0.0000280325619,
    "vs_currency": "USD",
    "cache_status": "MISS",
    "source": "jupiter"
  }
]
```