### PR TITLE
ci: deploy image for tag version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ on:
 name: Generalized Deployments
 jobs:
   push:
-    name: Invoke General Docker Build Pipeline
+    name: Deploy
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -23,9 +23,16 @@ jobs:
         role-to-assume: ${{ secrets.GDBP_AWS_IAM_ROLE_ARN }}
         aws-region: us-west-2
 
-    - name: Override GITHUB_REF for tagged releases
-      run: echo "GITHUB_REF_OVERRIDE=refs/heads/production" >> $GITHUB_ENV
+    - name: Deploy Tag Version
       if: startsWith(github.ref, 'refs/tags/')
+      uses: brave-intl/general-docker-build-pipeline-action@50a99c1f051b1d8e20ed79ded2e69ab3153b66e4 # v1.0.25
 
-    - name: Generalized Deployments
+    - name: Deploy to Production
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: brave-intl/general-docker-build-pipeline-action@50a99c1f051b1d8e20ed79ded2e69ab3153b66e4 # v1.0.25
+      env:
+        GITHUB_REF_OVERRIDE: refs/heads/production
+
+    - name: Deploy Branch
+      if: github.ref == 'refs/heads/master'
       uses: brave-intl/general-docker-build-pipeline-action@50a99c1f051b1d8e20ed79ded2e69ab3153b66e4 # v1.0.25


### PR DESCRIPTION
For tagged releases, we want to deploy images at both `production` tag as well as for the specific version.