### PR TITLE
fix(pricing): allow price lookups with unknown chain ids

### DIFF
--- a/app/api/pricing/cache.py
+++ b/app/api/pricing/cache.py
@@ -96,9 +96,9 @@ class CoingeckoPriceCache:
             return f"{cls.CACHE_PREFIX}:{param.coin_type.value.lower()}:{vs_currency.value.lower()}"
 
         if param.address:
-            return f"{cls.CACHE_PREFIX}:{param.coin_type.value.lower()}:{param.chain_id.value}:{param.address.lower()}:{vs_currency.value.lower()}"
+            return f"{cls.CACHE_PREFIX}:{param.coin_type.value.lower()}:{param.chain_id}:{param.address.lower()}:{vs_currency.value.lower()}"
 
-        return f"{cls.CACHE_PREFIX}:{param.coin_type.value.lower()}:{param.chain_id.value}:{vs_currency.value.lower()}"
+        return f"{cls.CACHE_PREFIX}:{param.coin_type.value.lower()}:{param.chain_id}:{vs_currency.value.lower()}"
 
 
 class JupiterPriceCache:

--- a/app/api/pricing/coingecko.py
+++ b/app/api/pricing/coingecko.py
@@ -166,13 +166,13 @@ class CoinGeckoClient:
                 return None
 
             for platform in platform_map.values():
-                if platform.chain_id == chain_id.value:
+                if platform.chain_id == chain_id:
                     return platform.native_token_id
 
             return None
 
         elif request.coin_type in [CoinType.SOL, CoinType.ETH]:
-            return coin_map.get(request.chain_id.value, {}).get(request.address.lower())
+            return coin_map.get(request.chain_id, {}).get(request.address.lower())
 
         return None
 

--- a/app/api/pricing/models.py
+++ b/app/api/pricing/models.py
@@ -28,7 +28,7 @@ class PriceSource(str, Enum):
 
 class TokenPriceRequest(BaseModel):
     coin_type: CoinType = Field(description=COIN_TYPE_DESCRIPTION)
-    chain_id: ChainId | None = Field(default=None, description=CHAIN_ID_DESCRIPTION)
+    chain_id: str | None = Field(default=None, description=CHAIN_ID_DESCRIPTION)
     address: str | None = Field(default=None, description=ADDRESS_DESCRIPTION)
 
     @model_validator(mode="after")
@@ -53,7 +53,7 @@ class TokenPriceRequest(BaseModel):
                 {
                     "coin_type": CoinType.SOL,
                     "chain_id": ChainId.SOLANA,
-                    "address": "",
+                    "address": None,
                 },
                 {
                     "coin_type": CoinType.SOL,

--- a/app/api/pricing/routes.py
+++ b/app/api/pricing/routes.py
@@ -36,7 +36,7 @@ async def get_price(
         description=COIN_TYPE_DESCRIPTION,
         examples=[CoinType.ETH, CoinType.BTC, CoinType.SOL],
     ),
-    chain_id: ChainId | None = Query(
+    chain_id: str | None = Query(
         default=None,
         description=CHAIN_ID_DESCRIPTION,
         examples=[ChainId.ETHEREUM, ChainId.BASE],


### PR DESCRIPTION
User's wallet may have active chain ids that are not supported by gate3. This should not fail the entire requests. The token price lookups for unknown chains should simply be skipped.