### PR TITLE
chore(nft): use internal calls for simplehash instead of redirecting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gate3"
-version = "0.3.1"
+version = "0.4.0"
 description = "Gate API for web3 applications at Brave"
 authors = [
 ]


### PR DESCRIPTION
Amazon ALB cannot handle nested 307 redirects. Call the internal route functions directly (with 200 status code) instead of returning a redirect response with 307.

I followed TDD with the unit tests. Made sure the route tests were passing before and after making the changes to `app/api/nft/routes.py`.