### PR TITLE
perf(pricing): query coingecko and jupiter prices concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,7 @@
 
 A FastAPI-based gateway service for web3 applications at Brave.
 
-
-## API documentation
-
-| Environment | Access Control | URL |
-|-------------|----------------|------------------|
-| Staging (internal) | Internal Brave VPN | [`gate3-srv.bsg.brave.software/docs`](https://gate3-srv.bsg.brave.software/docs) |
-| Staging | Brave Services Key | [`gate3.bsg.brave.software/docs`](https://gate3.bsg.brave.software/docs) |
-| Production | Brave Services Key | [`gate3.bsg.brave.com/docs`](https://gate3.bsg.brave.com/docs) |
+**Documentation:** [`gate3.bsg.brave.com/docs`](https://gate3.bsg.brave.com/docs) (requires Brave VPN)
 
 
 ## Prerequisites
@@ -53,6 +46,14 @@ A FastAPI-based gateway service for web3 applications at Brave.
     poetry run fastapi dev
     ```
 
-### Deployment
+### Deployments
 
 Deployments are managed using the [generalized docker build pipeline](https://github.com/brave-intl/general-docker-build-pipeline-action). To create a new deployment, simply publish a new release on GitHub.
+
+gate3 is currently deployed to the following environments:
+
+| Environment | Access Control | URL |
+|-------------|----------------|------------------|
+| Production (internal) | Internal Brave VPN | `gate3.bsg.brave.com` |
+| Production | Brave Services Key | `gate3.wallet.brave.com` |
+| Staging | Brave Services Key | `gate3.wallet.brave.software` |

--- a/app/api/pricing/routes.py
+++ b/app/api/pricing/routes.py
@@ -1,18 +1,15 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+import asyncio
+
+from fastapi import APIRouter, Depends, Query
 
 from app.api.common.annotations import (
-    ADDRESS_DESCRIPTION,
-    CHAIN_ID_DESCRIPTION,
-    COIN_DESCRIPTION,
     VS_CURRENCY_DESCRIPTION,
 )
-from app.api.common.models import Chain
 
 from .coingecko import CoinGeckoClient
 from .jupiter import JupiterClient
 from .models import (
     BatchTokenPriceRequests,
-    Coin,
     TokenPriceRequest,
     TokenPriceResponse,
     VsCurrency,
@@ -28,60 +25,6 @@ def get_coingecko_client() -> CoinGeckoClient:
 
 def get_jupiter_client() -> JupiterClient:
     return JupiterClient()
-
-
-@router.get("/v1/getPrice", response_model=TokenPriceResponse)
-async def get_price(
-    coin: Coin = Query(
-        description=COIN_DESCRIPTION,
-        examples=[Chain.ETHEREUM.coin, Chain.BITCOIN.coin, Chain.SOLANA.coin],
-    ),
-    chain_id: str = Query(
-        description=CHAIN_ID_DESCRIPTION,
-        examples=[
-            Chain.ETHEREUM.chain_id,
-            Chain.BITCOIN.chain_id,
-            Chain.SOLANA.chain_id,
-        ],
-    ),
-    address: str | None = Query(
-        default=None,
-        description=ADDRESS_DESCRIPTION,
-        examples=["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"],
-    ),
-    vs_currency: VsCurrency = Query(
-        default=VsCurrency.USD,
-        description=VS_CURRENCY_DESCRIPTION,
-        examples=[VsCurrency.USD, VsCurrency.EUR],
-    ),
-    coingecko_client: CoinGeckoClient = Depends(get_coingecko_client),
-    jupiter_client: JupiterClient = Depends(get_jupiter_client),
-) -> TokenPriceResponse:
-    """
-    Get token price of a token on a given chain against a specific base currency.
-    Chain ID and address are required only for Ethereum and Solana tokens.
-    """
-    request = TokenPriceRequest(coin=coin, chain_id=chain_id, address=address)
-    batch = BatchTokenPriceRequests(requests=[request], vs_currency=vs_currency)
-
-    # Try CoinGecko first
-    coingecko_available, coingecko_unavailable = await coingecko_client.filter(batch)
-
-    if not coingecko_available.is_empty():
-        results = await coingecko_client.get_prices(coingecko_available)
-        if results:
-            return results[0]
-
-    # For tokens that are not available in CoinGecko, try Jupiter Price API
-    jupiter_available, _ = await jupiter_client.filter(coingecko_unavailable)
-    if not jupiter_available.is_empty():
-        results = await jupiter_client.get_prices(
-            batch=jupiter_available, coingecko_client=coingecko_client
-        )
-        if results:
-            return results[0]
-
-    raise HTTPException(status_code=404, detail="Token price not found")
 
 
 @router.post("/v1/getPrices", response_model=list[TokenPriceResponse])
@@ -104,15 +47,24 @@ async def get_prices(
     # Deduplicate requests
     batch = deduplicate_batch(batch)
 
-    # Try CoinGecko first
+    # Filter tokens for CoinGecko
     coingecko_available, coingecko_unavailable = await coingecko_client.filter(batch)
-    coingecko_results = await coingecko_client.get_prices(coingecko_available)
-
-    # For tokens that are not available in CoinGecko, try Jupiter Price API
+    # For tokens that are not available on CoinGecko, try Jupiter
     jupiter_available, _ = await jupiter_client.filter(coingecko_unavailable)
-    jupiter_results = await jupiter_client.get_prices(
-        batch=jupiter_available, coingecko_client=coingecko_client
-    )
 
-    # Combine results
-    return coingecko_results + jupiter_results
+    # Prepare tasks for parallel execution
+    tasks = [
+        coingecko_client.get_prices(coingecko_available),
+        jupiter_client.get_prices(
+            batch=jupiter_available, coingecko_client=coingecko_client
+        ),
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Handle exceptions and collect valid results
+    return [
+        item
+        for result in results
+        if not isinstance(result, Exception) and result
+        for item in result
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gate3"
-version = "0.6.0"
+version = "0.7.0"
 description = "Gate API for web3 applications at Brave"
 authors = [
 ]


### PR DESCRIPTION
Prices from Coingecko and Jupiter APIs can be fetched concurrently since they are mutually exclusive in our usage.

Also remove `/api/pricing/v1/getPrice` endpoint, since it's unlikely to ever find a use-case.