### PR TITLE
fix(tokens): handle null decimals value in tokens

### DIFF
--- a/app/api/tokens/manager.py
+++ b/app/api/tokens/manager.py
@@ -98,13 +98,17 @@ class TokenManager:
                         if not chain:
                             continue
 
+                        decimals = raw_token_info.get("decimals")
+                        if not decimals:
+                            continue
+
                         token_info = TokenInfo(
                             coin=chain.coin,
                             chain_id=chain.chain_id,
                             address=address,
                             name=raw_token_info["name"],
                             symbol=raw_token_info["symbol"],
-                            decimals=raw_token_info["decimals"],
+                            decimals=decimals,
                             logo=raw_token_info["logo"],
                             sources=[],  # We'll add sources later
                         )


### PR DESCRIPTION
Some tokens in the Coingecko Universe tokens list (https://raw.githubusercontent.com/brave/token-lists/refs/heads/main/data/v1/coingecko.json) have `null` values in the `decimals` field.

We should skip tokens since they cannot be reliably used in Brave Wallet. We should also investigate why those tokens have `null` decimals in https://github.com/brave/token-lists.