### PR TITLE
fix(nft): ignore name and description fields in NFT metadata

### DIFF
--- a/app/api/nft/models.py
+++ b/app/api/nft/models.py
@@ -48,8 +48,6 @@ class TraitAttribute(BaseModel):
 
 
 class AlchemyRawMetadata(BaseModel):
-    name: str | None = None
-    description: str | None = None
     image: str | None = None
     external_url: str | None = None
     attributes: list[TraitAttribute] = Field(default_factory=list)


### PR DESCRIPTION
The `name` and `description` fields are unused and have unreliable types. These fields are ignored in pydantic validation.

Resolves https://github.com/brave/gate3/issues/92