### PR TITLE
dev: reduce traces sampling rate to 10%

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     environment=settings.ENVIRONMENT,
     release=f"gate3@{version}",
-    traces_sample_rate=1.0,
+    traces_sample_rate=0.1,
 )
 
 


### PR DESCRIPTION
We are hitting the limit of the number of traces Sentry can handle. This PR reduces the number of traces collection by 10x.