### PR TITLE
dev: reduce traces sampling rate to 1%

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     environment=settings.ENVIRONMENT,
     release=f"gate3@{version}",
-    traces_sample_rate=0.1,
+    traces_sample_rate=0.01,
 )
 
 


### PR DESCRIPTION
We need to further reduce the sampling rate to stay under the 5M traces/month quota on Sentry.