### PR TITLE
dev: disable sentry traces

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,6 @@ sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     environment=settings.ENVIRONMENT,
     release=f"gate3@{version}",
-    traces_sample_rate=0.01,
 )
 
 


### PR DESCRIPTION
gate3 still reports a lot of traces, way more than our quota allows.

<img width="4852" height="552" alt="image" src="https://github.com/user-attachments/assets/37353b5e-1d12-427a-ad63-d489af7bb2af" />

Monthly quota for all projects: 5M traces (+5M gifted by Sentry). The app consumes 10M in ~3.5 days. All traces above that threshold get charged in a pay-as-you-go model.