### PR TITLE
chore(swap): rename fields of base swap models

### DIFF
--- a/app/api/swap/models.py
+++ b/app/api/swap/models.py
@@ -136,9 +136,9 @@ class SwapQuoteRequest(SwapSupportRequest):
     )
 
     # Swap parameters
-    slippage_tolerance: int = Field(
-        default=50,
-        description="Slippage tolerance in basis points (e.g., 50 = 0.5%)",
+    slippage_percentage: str = Field(
+        default="0.5",
+        description="Slippage tolerance as a percentage string (e.g., '0.5' = 0.5%)",
     )
     swap_type: SwapType = Field(
         default=SwapType.EXACT_INPUT,
@@ -158,24 +158,16 @@ class SwapQuoteRequest(SwapSupportRequest):
 class SwapQuote(BaseModel):
     """Normalized swap quote response"""
 
-    amount_in: str = Field(description="Input amount in smallest unit")
-    amount_in_formatted: str = Field(description="Input amount in readable format")
-    amount_in_usd: str | None = Field(default=None, description="Input amount in USD")
+    source_amount: str = Field(description="Source amount in smallest unit")
 
-    amount_out: str = Field(description="Expected output amount in smallest unit")
-    amount_out_formatted: str = Field(
-        description="Expected output amount in readable format"
-    )
-    amount_out_usd: str | None = Field(
-        default=None, description="Expected output amount in USD"
+    destination_amount: str = Field(description="Destination amount in smallest unit")
+
+    destination_amount_min: str = Field(
+        description="Minimum destination amount after slippage in smallest unit"
     )
 
-    min_amount_out: str = Field(
-        description="Minimum output amount after slippage in smallest unit"
-    )
-
-    estimated_time: int = Field(
-        description="Estimated time for swap completion in seconds"
+    estimated_time: int | None = Field(
+        default=None, description="Estimated time for swap completion in seconds"
     )
 
     deposit_address: str | None = Field(
@@ -225,18 +217,12 @@ class SwapDetails(BaseModel):
     amount_in_formatted: str | None = Field(
         default=None, description="Actual input amount in readable format"
     )
-    amount_in_usd: str | None = Field(
-        default=None, description="Actual input amount in USD"
-    )
 
     amount_out: str | None = Field(
         default=None, description="Actual output amount in smallest unit"
     )
     amount_out_formatted: str | None = Field(
         default=None, description="Actual output amount in readable format"
-    )
-    amount_out_usd: str | None = Field(
-        default=None, description="Actual output amount in USD"
     )
 
     refunded_amount: str | None = Field(

--- a/app/api/swap/providers/near_intents/test_client.py
+++ b/app/api/swap/providers/near_intents/test_client.py
@@ -326,7 +326,7 @@ async def test_get_indicative_quote_success(
         destination_token_address=None,
         recipient="bc1qpjqsdj3qvfl4hzfa49p28ns9xkpl73cyg9exzn",
         amount="2037265",
-        slippage_tolerance=50,
+        slippage_percentage="0.5",
         swap_type=SwapType.EXACT_INPUT,
         sender="8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT",
         provider=SwapProviderEnum.NEAR_INTENTS,
@@ -344,8 +344,8 @@ async def test_get_indicative_quote_success(
 
     # Verify response
     assert result.provider == SwapProviderEnum.NEAR_INTENTS
-    assert result.quote.amount_in == "2037265"
-    assert result.quote.amount_out == "711"
+    assert result.quote.source_amount == "2037265"
+    assert result.quote.destination_amount == "711"
     assert (
         result.quote.deposit_address is None
     )  # Indicative quote has no deposit address
@@ -386,7 +386,7 @@ async def test_get_firm_quote_success(
         destination_token_address=None,
         recipient="bc1qpjqsdj3qvfl4hzfa49p28ns9xkpl73cyg9exzn",
         amount="2037265",
-        slippage_tolerance=50,
+        slippage_percentage="0.5",
         swap_type=SwapType.EXACT_INPUT,
         sender="8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT",
         provider=SwapProviderEnum.NEAR_INTENTS,
@@ -404,8 +404,8 @@ async def test_get_firm_quote_success(
 
     # Verify response
     assert result.provider == SwapProviderEnum.NEAR_INTENTS
-    assert result.quote.amount_in == "2037265"
-    assert result.quote.amount_out == "711"
+    assert result.quote.source_amount == "2037265"
+    assert result.quote.destination_amount == "711"
     assert (
         result.quote.deposit_address == "9RdSjLtfFJLvj6CAR4w7H7tUbv2kvwkkrYZuoojKDBkE"
     )
@@ -443,7 +443,7 @@ async def test_get_quote_error_response(
         destination_token_address=None,
         recipient="bc1qpjqsdj3qvfl4hzfa49p28ns9xkpl73cyg9exzn",
         amount="2037265",
-        slippage_tolerance=50,
+        slippage_percentage="0.5",
         swap_type=SwapType.EXACT_INPUT,
         sender="8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT",
         provider=SwapProviderEnum.NEAR_INTENTS,
@@ -672,7 +672,7 @@ async def test_quote_price_impact_with_usd_values(
         destination_token_address=None,
         recipient="bc1qpjqsdj3qvfl4hzfa49p28ns9xkpl73cyg9exzn",
         amount="2037265",
-        slippage_tolerance=50,
+        slippage_percentage="0.5",
         swap_type=SwapType.EXACT_INPUT,
         sender="8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT",
         provider=SwapProviderEnum.NEAR_INTENTS,
@@ -732,7 +732,7 @@ async def test_quote_price_impact_none_cases(
         destination_token_address=None,
         recipient="bc1qpjqsdj3qvfl4hzfa49p28ns9xkpl73cyg9exzn",
         amount="2037265",
-        slippage_tolerance=50,
+        slippage_percentage="0.5",
         swap_type=SwapType.EXACT_INPUT,
         sender="8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT",
         provider=SwapProviderEnum.NEAR_INTENTS,
@@ -777,7 +777,7 @@ async def test_quote_price_impact_positive_impact(
         destination_token_address=None,
         recipient="bc1qpjqsdj3qvfl4hzfa49p28ns9xkpl73cyg9exzn",
         amount="2037265",
-        slippage_tolerance=50,
+        slippage_percentage="0.5",
         swap_type=SwapType.EXACT_INPUT,
         sender="8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT",
         provider=SwapProviderEnum.NEAR_INTENTS,

--- a/app/api/swap/providers/near_intents/transformations.py
+++ b/app/api/swap/providers/near_intents/transformations.py
@@ -61,11 +61,16 @@ def to_near_intents_request(
     request.set_source_token(supported_tokens)
     request.set_destination_token(supported_tokens)
 
+    # Convert percentage string to basis points (bps) for near intents
+    # e.g., "0.5" -> 50 bps, "1.0" -> 100 bps
+    slippage_percentage = float(request.slippage_percentage)
+    slippage_bps = int(slippage_percentage * 100)
+
     return NearIntentsQuoteRequestBody(
         dry=dry,
         deposit_mode=NearIntentsDepositMode.SIMPLE,
         swap_type=request.swap_type,
-        slippage_tolerance=request.slippage_tolerance,
+        slippage_tolerance=slippage_bps,
         origin_asset_id=request.source_token.near_intents_asset_id,
         destination_asset_id=request.destination_token.near_intents_asset_id,
         amount=request.amount,
@@ -101,13 +106,9 @@ def from_near_intents_quote(response: NearIntentsQuoteResponse) -> SwapQuoteResp
     price_impact = _calculate_price_impact(quote_data)
 
     quote = SwapQuote(
-        amount_in=quote_data.amount_in,
-        amount_in_formatted=quote_data.amount_in_formatted,
-        amount_in_usd=quote_data.amount_in_usd,
-        amount_out=quote_data.amount_out,
-        amount_out_formatted=quote_data.amount_out_formatted,
-        amount_out_usd=quote_data.amount_out_usd,
-        min_amount_out=quote_data.min_amount_out,
+        source_amount=quote_data.amount_in,
+        destination_amount=quote_data.amount_out,
+        destination_amount_min=quote_data.min_amount_out,
         estimated_time=quote_data.time_estimate,
         deposit_address=quote_data.deposit_address,
         deposit_memo=quote_data.deposit_memo,


### PR DESCRIPTION
* Remove some unnecessary fields from the base models.
* Require slippage percentage instead of basis points, which allows fractional bps as required in some swap providers.
* Rename some fields for better clarity.