### PR TITLE
chore(swap): use alias generators in swap models

### DIFF
--- a/app/api/swap/models.py
+++ b/app/api/swap/models.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.api.common.models import Chain, Coin, TokenInfo
+from pydantic.alias_generators import to_camel
 
 # ============================================================================
 # Public Enums (Provider-Agnostic)
@@ -89,8 +90,17 @@ class SwapSupportRequest(BaseModel):
         default=None, description="Recipient address on destination chain"
     )
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     _source_token: TokenInfo | None = None
     _destination_token: TokenInfo | None = None
+
+    @field_validator(
+        "source_token_address", "destination_token_address", "recipient", mode="before"
+    )
+    @classmethod
+    def empty_string_to_none(cls, v: str | None) -> str | None:
+        return None if v == "" else v
 
     @property
     def source_chain(self) -> Chain | None:

--- a/app/api/swap/providers/near_intents/client.py
+++ b/app/api/swap/providers/near_intents/client.py
@@ -77,13 +77,7 @@ class NearIntentsClient(BaseSwapProvider):
 
     @staticmethod
     def _is_address_equal(a: str | None, b: str | None) -> bool:
-        if a is None and b is None:
-            return True
-
-        if a is None or b is None:
-            return False
-
-        return a.lower() == b.lower()
+        return (a or "").lower() == (b or "").lower()
 
     async def has_support(self, request: SwapSupportRequest) -> bool:
         if not request.source_chain or not request.destination_chain:

--- a/app/api/swap/providers/near_intents/models.py
+++ b/app/api/swap/providers/near_intents/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
 
 from ...models import SwapType
 
@@ -11,7 +12,9 @@ class NearIntentsToken(BaseModel):
     decimals: int
     blockchain: str
     symbol: str
-    contract_address: str | None = Field(default=None, alias="contractAddress")
+    contract_address: str | None = Field(default=None)
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class NearIntentsDepositMode(str, Enum):
@@ -21,85 +24,95 @@ class NearIntentsDepositMode(str, Enum):
 
 class NearIntentsQuoteRequestBody(BaseModel):
     dry: bool = Field(default=False, description="Dry run flag")
-    deposit_mode: NearIntentsDepositMode = Field(alias="depositMode")
-    swap_type: SwapType = Field(alias="swapType")
-    slippage_tolerance: int = Field(alias="slippageTolerance")
-    origin_asset_id: str = Field(alias="originAsset")
-    deposit_type: str = Field(default="ORIGIN_CHAIN", alias="depositType")
-    destination_asset_id: str = Field(alias="destinationAsset")
+    deposit_mode: NearIntentsDepositMode
+    swap_type: SwapType
+    slippage_tolerance: int
+    origin_asset_id: str = Field(alias="originAsset")  # Exception: not originAssetId
+    deposit_type: str = Field(default="ORIGIN_CHAIN")
+    destination_asset_id: str = Field(
+        alias="destinationAsset"
+    )  # Exception: not destinationAssetId
     amount: str
-    refund_to: str = Field(alias="refundTo")
-    refund_type: str = Field(default="ORIGIN_CHAIN", alias="refundType")
+    refund_to: str
+    refund_type: str = Field(default="ORIGIN_CHAIN")
     recipient: str
-    recipient_type: str = Field(default="DESTINATION_CHAIN", alias="recipientType")
+    recipient_type: str = Field(default="DESTINATION_CHAIN")
     deadline: str
     referral: str = Field(default="brave")
-    quote_waiting_time_ms: int = Field(default=0, alias="quoteWaitingTimeMs")
+    quote_waiting_time_ms: int = Field(default=0)
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class NearIntentsQuoteData(BaseModel):
-    amount_in: str = Field(alias="amountIn")
-    amount_in_formatted: str = Field(alias="amountInFormatted")
-    amount_in_usd: str | None = Field(default=None, alias="amountInUsd")
-    min_amount_in: str | None = Field(default=None, alias="minAmountIn")
+    amount_in: str
+    amount_in_formatted: str
+    amount_in_usd: str | None = Field(default=None)
+    min_amount_in: str | None = Field(default=None)
 
-    amount_out: str = Field(alias="amountOut")
-    amount_out_formatted: str = Field(alias="amountOutFormatted")
-    amount_out_usd: str | None = Field(default=None, alias="amountOutUsd")
-    min_amount_out: str = Field(alias="minAmountOut")
+    amount_out: str
+    amount_out_formatted: str
+    amount_out_usd: str | None = Field(default=None)
+    min_amount_out: str
 
     deadline: datetime | None = None
-    time_when_inactive: datetime | None = Field(default=None, alias="timeWhenInactive")
-    time_estimate: int = Field(alias="timeEstimate")
+    time_when_inactive: datetime | None = Field(default=None)
+    time_estimate: int
 
-    deposit_address: str | None = Field(default=None, alias="depositAddress")
-    deposit_memo: str | None = Field(default=None, alias="depositMemo")
+    deposit_address: str | None = Field(default=None)
+    deposit_memo: str | None = Field(default=None)
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class NearIntentsQuoteResponse(BaseModel):
-    quote_request: NearIntentsQuoteRequestBody = Field(alias="quoteRequest")
+    quote_request: NearIntentsQuoteRequestBody
     quote: NearIntentsQuoteData
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class NearIntentsTransactionDetails(BaseModel):
     hash: str
-    explorer_url: str | None = Field(default=None, alias="explorerUrl")
+    explorer_url: str | None = Field(default=None)
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class NearIntentsSwapDetails(BaseModel):
     """Swap details from NEAR Intents status response"""
 
-    intent_hashes: list[str] = Field(default_factory=list, alias="intentHashes")
-    near_tx_hashes: list[str] = Field(default_factory=list, alias="nearTxHashes")
+    intent_hashes: list[str] = Field(default_factory=list)
+    near_tx_hashes: list[str] = Field(default_factory=list)
 
-    amount_in: str | None = Field(default=None, alias="amountIn")
-    amount_in_formatted: str | None = Field(default=None, alias="amountInFormatted")
-    amount_in_usd: str | None = Field(default=None, alias="amountInUsd")
+    amount_in: str | None = Field(default=None)
+    amount_in_formatted: str | None = Field(default=None)
+    amount_in_usd: str | None = Field(default=None)
 
-    amount_out: str | None = Field(default=None, alias="amountOut")
-    amount_out_formatted: str | None = Field(default=None, alias="amountOutFormatted")
-    amount_out_usd: str | None = Field(default=None, alias="amountOutUsd")
+    amount_out: str | None = Field(default=None)
+    amount_out_formatted: str | None = Field(default=None)
+    amount_out_usd: str | None = Field(default=None)
 
-    refunded_amount: str | None = Field(default=None, alias="refundedAmount")
-    refunded_amount_formatted: str | None = Field(
-        default=None, alias="refundedAmountFormatted"
-    )
+    refunded_amount: str | None = Field(default=None)
+    refunded_amount_formatted: str | None = Field(default=None)
 
     origin_chain_tx_hashes: list[NearIntentsTransactionDetails] = Field(
-        default_factory=list, alias="originChainTxHashes"
+        default_factory=list
     )
     destination_chain_tx_hashes: list[NearIntentsTransactionDetails] = Field(
-        default_factory=list, alias="destinationChainTxHashes"
+        default_factory=list
     )
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class NearIntentsStatusResponse(BaseModel):
-    quote_response: NearIntentsQuoteResponse = Field(alias="quoteResponse")
+    quote_response: NearIntentsQuoteResponse
     status: str
-    updated_at: datetime = Field(alias="updatedAt")
-    swap_details: NearIntentsSwapDetails = Field(alias="swapDetails")
+    updated_at: datetime
+    swap_details: NearIntentsSwapDetails
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class NearIntentsError(BaseModel):


### PR DESCRIPTION
Allow Pydantic to use both:

- **camelCase** field names — for JSON serialization/deserialization (API requests/responses)
- **snake_case** field names (original Python field names) — for Python code usage (tests, internal code)