### PR TITLE
fix(swap): convert expires_at to Unix timestamp string

### DIFF
--- a/app/api/swap/models.py
+++ b/app/api/swap/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -428,9 +427,9 @@ class SwapRoute(SwapBaseModel):
         default=None,
         description="Memo required for deposit (if applicable, e.g., for Stellar)",
     )
-    expires_at: datetime | None = Field(
+    expires_at: str | None = Field(
         default=None,
-        description="Expiration time for the quote/deposit address",
+        description="Expiration time for the quote/deposit address as Unix timestamp",
     )
     transaction_params: TransactionParams | None = Field(
         default=None,

--- a/app/api/swap/providers/near_intents/transformations.py
+++ b/app/api/swap/providers/near_intents/transformations.py
@@ -278,6 +278,12 @@ async def from_near_intents_quote_to_route(
     if request.swap_type == SwapType.EXACT_OUTPUT:
         source_amount_min = quote_data.min_amount_in
 
+    # Convert deadline datetime to Unix timestamp string
+    expires_at = None
+    if quote_data.deadline:
+        # Convert datetime to Unix timestamp (seconds since epoch)
+        expires_at = str(int(quote_data.deadline.timestamp()))
+
     return SwapRoute(
         id=route_id,
         provider=SwapProviderEnum.NEAR_INTENTS,
@@ -290,7 +296,7 @@ async def from_near_intents_quote_to_route(
         network_fee=network_fee,
         deposit_address=quote_data.deposit_address,
         deposit_memo=quote_data.deposit_memo,
-        expires_at=quote_data.deadline,
+        expires_at=expires_at,
         transaction_params=transaction_params,
         has_post_submit_hook=has_post_submit_hook,
         requires_token_allowance=requires_token_allowance,


### PR DESCRIPTION
Unix timestamp format is easier to parser and more versatile across swap providers.