### PR TITLE
Update Generalized Deployment Action to Prevent Double Image Deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,10 +23,6 @@ jobs:
         role-to-assume: ${{ secrets.GDBP_AWS_IAM_ROLE_ARN }}
         aws-region: us-west-2
 
-    - name: Deploy Tag Version
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: brave-intl/general-docker-build-pipeline-action@50a99c1f051b1d8e20ed79ded2e69ab3153b66e4 # v1.0.25
-
     - name: Deploy to Production
       if: startsWith(github.ref, 'refs/tags/')
       uses: brave-intl/general-docker-build-pipeline-action@50a99c1f051b1d8e20ed79ded2e69ab3153b66e4 # v1.0.25


### PR DESCRIPTION
Updates generalized deployment github action to prevent double image push.  Gate3-ops uses `168134825737.dkr.ecr.us-west-2.amazonaws.com/brave/gate3/production:<tag>` for the image deployments (which is covered by `Deploy to Production` step.  `Deploy Tag Version` creates the image `168134825737.dkr.ecr.us-west-2.amazonaws.com/brave/gate3/v<github-release-tag>:<tag>` which never gets used.
