### PR TITLE
perf(api): use ORJSONResponse as default response class

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 import sentry_sdk
 from fastapi import FastAPI
+from fastapi.responses import ORJSONResponse
 from prometheus_client import start_http_server
 from prometheus_fastapi_instrumentator import Instrumentator
 
@@ -53,7 +54,7 @@ async def lifespan(app: FastAPI):
         yield
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan, default_response_class=ORJSONResponse)
 Instrumentator().instrument(app)
 
 # API routers


### PR DESCRIPTION
## Summary

Set `default_response_class=ORJSONResponse` on the FastAPI app. Every route that doesn't explicitly choose a response class now serializes JSON via `orjson` instead of the stdlib encoder.

## Benchmark

`ab -n 20000 -c 100 -k` against the app running under `docker compose` with `fastapi run`. Client and server share the host.

| Endpoint | RPS (baseline → enhancement) | Δ RPS | p50 (ms) | p95 (ms) | p99 (ms) |
| -------- | --------------------- | ----- | -------- | -------- | -------- |
| `/api/ping` | 773 → 788 | +1.9% | 126 → 126 | 143 → **134** | 228 → **154** |
| `/api/swap/v1/providers` | 907 → 890 | -1.9% | 110 → 112 | 115 → 117 | 123 → 121 |