### PR TITLE
perf: invoke uvicorn directly instead of via fastapi run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,53 @@ jobs:
 
     - name: Run tests
       run: poetry run pytest
+
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.14'
+
+    - name: Install Poetry
+      uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Install project
+      run: poetry install --no-interaction --all-extras
+
+    - name: Prepare env file for compose
+      run: cp env.test .env
+
+    - name: Start app via docker compose
+      run: docker compose up -d --build
+
+    - name: Wait for app to become healthy
+      run: |
+        for i in $(seq 1 60); do
+          if curl -fsS http://localhost:8000/api/ping >/dev/null; then
+            echo "App is up after ${i}s"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "App failed to become healthy in 60s" >&2
+        exit 1
+
+    - name: Run integration tests
+      run: poetry run pytest integration/ --no-cov -v
+
+    - name: Dump app logs
+      if: always()
+      run: docker compose logs app
+
+    - name: Tear down compose stack
+      if: always()
+      run: docker compose down -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY ./app /code/app
 COPY ./data /code/data
 
 # Run the application
-CMD ["fastapi", "run", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]
 
 # Expose the Prometheus port
 EXPOSE 8090

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,0 +1,16 @@
+import os
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    return os.environ.get("INTEGRATION_BASE_URL", "http://localhost:8000")
+
+
+@pytest_asyncio.fixture
+async def client(base_url: str):
+    async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as c:
+        yield c

--- a/integration/test_ping.py
+++ b/integration/test_ping.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_ping_reports_redis_ok(client):
+    response = await client.get("/api/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"redis": "OK"}

--- a/integration/test_swap.py
+++ b/integration/test_swap.py
@@ -1,0 +1,34 @@
+import pytest
+
+USDC_MAINNET = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+VITALIK = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+
+
+@pytest.mark.asyncio
+async def test_indicative_quote_eth_to_usdc_via_lifi(client):
+    body = {
+        "source_coin": "ETH",
+        "source_chain_id": "0x1",
+        "source_token_address": None,
+        "destination_coin": "ETH",
+        "destination_chain_id": "0x1",
+        "destination_token_address": USDC_MAINNET,
+        "recipient": VITALIK,
+        "amount": "100000000000000000",
+        "slippage_percentage": "0.5",
+        "swap_type": "EXACT_INPUT",
+        "refund_to": VITALIK,
+        "provider": "LIFI",
+    }
+
+    response = await client.post("/api/swap/v1/quote/indicative", json=body)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert "routes" in payload
+    assert len(payload["routes"]) >= 1
+
+    route = payload["routes"][0]
+    assert route["provider"] == "LIFI"
+    assert int(route["sourceAmount"]) == 10**17
+    assert int(route["destinationAmount"]) > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gate3"
-version = "0.17.1"
+version = "0.18.0"
 description = "Gate API for web3 applications at Brave"
 authors = [
 ]
@@ -42,7 +42,7 @@ respx = "0.23.1"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
-addopts = "-rvA --cov=app --cov-report=term-missing"
+addopts = "-rvA --cov=app --cov-report=term-missing --ignore=integration"
 markers = [
     "sanity: marks tests as sanity checks",
 ]


### PR DESCRIPTION
Dockerfile CMD switched from `fastapi run` to `uvicorn`. Everything else in the image is identical. Ran `ab` over loopback with caches warmed first.

Added basic integration tests to make sure nothing breaks.

#### Heavy load: `ab -n 20000 -c 100 -k`

`/api/ping` (handler plus a Redis round-trip)

| Variant |  RPS | p50 (ms) | p95 (ms) | p99 (ms) |
| ------- | ---: | -------: | -------: | -------: |
| master  |  801 |      124 |      130 |      153 |
| branch  | 1061 |       90 |      121 |      147 |
| **Δ**   | **+32%** | **−27%** | **−7%** | **−4%** |

`/api/swap/v1/providers` (static JSON)

| Variant |  RPS | p50 (ms) | p95 (ms) | p99 (ms) |
| ------- | ---: | -------: | -------: | -------: |
| master  |  870 |      112 |      130 |      141 |
| branch  | 1293 |       77 |       80 |       85 |
| **Δ**   | **+49%** | **−31%** | **−38%** | **−40%** |

#### Light load: `ab -n 30 -c 1 -k`

`/api/swap/v1/providers/supported` (GET, hits TokenManager)

| Variant | mean (ms) | p50 | p95 | p99 |
| ------- | --------: | --: | --: | --: |
| master  |      3.00 |   3 |   5 |   9 |
| branch  |      2.27 |   2 |   3 |   3 |
| **Δ**   | **−24%** | **−33%** | **−40%** | **−67%** |

### Takeaway

The branch wins across the board on server-bound endpoints. The biggest gains land on the pure-CPU paths (`providers` and `supported`), where fastapi-cli's wrapper cost is a larger share of the work. Zero failed requests in any of the runs. One caveat: loopback inflates these deltas, so on a real network the gains will be smaller.