### PR TITLE
feat(pricing): add support for DOT prices

### DIFF
--- a/app/api/common/models.py
+++ b/app/api/common/models.py
@@ -33,6 +33,7 @@ class PingResponse(BaseModel):
 class Coin(str, Enum):
     ADA = "ADA"
     BTC = "BTC"
+    DOT = "DOT"
     ETH = "ETH"
     FIL = "FIL"
     SOL = "SOL"
@@ -214,6 +215,18 @@ class Chain(Enum):
         native_asset_name="Zcash",
         symbol="ZEC",
         decimals=8,
+    )
+    POLKADOT = _c(
+        coin=Coin.DOT,
+        chain_id="polkadot_mainnet",
+        simplehash_id="polkadot",
+        alchemy_id="polkadot-mainnet",
+        near_intents_id=None,
+        has_nft_support=False,
+        name="Polkadot",
+        native_asset_name="Polkadot",
+        symbol="DOT",
+        decimals=10,
     )
 
     def __getattr__(self, name):

--- a/app/api/pricing/coingecko.py
+++ b/app/api/pricing/coingecko.py
@@ -176,6 +176,9 @@ class CoinGeckoClient:
         elif chain == Chain.ZCASH:
             return "zcash"
 
+        elif chain == Chain.POLKADOT:
+            return "polkadot"
+
         elif chain == Chain.SOLANA and not request.address:
             return "solana"
 

--- a/app/api/pricing/tests/test_coingecko.py
+++ b/app/api/pricing/tests/test_coingecko.py
@@ -130,6 +130,47 @@ async def test_filter_excludes_native_token_with_null_native_token_id(client):
 
 
 @pytest.mark.asyncio
+async def test_native_polkadot_resolves_to_coingecko_id(client):
+    """Native DOT (polkadot_mainnet) maps to the 'polkadot' CoinGecko id."""
+    request = TokenPriceRequest(
+        coin=Chain.POLKADOT.coin, chain_id=Chain.POLKADOT.chain_id, address=None
+    )
+
+    coingecko_id = await client._get_coingecko_id_from_request(
+        request, platform_map={}, coin_map={}
+    )
+
+    assert coingecko_id == "polkadot"
+
+
+@pytest.mark.asyncio
+async def test_filter_includes_native_polkadot(client):
+    """Native DOT is available on CoinGecko without needing platform/coin maps."""
+    batch = BatchTokenPriceRequests(
+        requests=[
+            TokenPriceRequest(
+                coin=Chain.POLKADOT.coin,
+                chain_id=Chain.POLKADOT.chain_id,
+                address=None,
+            ),
+        ],
+        vs_currency=VsCurrency.USD,
+    )
+
+    with (
+        patch.object(client, "get_platform_map") as mock_platform_map,
+        patch.object(client, "get_coin_map") as mock_coin_map,
+    ):
+        mock_platform_map.return_value = {}
+        mock_coin_map.return_value = {}
+
+        available, unavailable = await client.filter(batch)
+
+        assert available.size() == 1
+        assert unavailable.is_empty()
+
+
+@pytest.mark.asyncio
 async def test_filter_includes_native_token_when_native_token_id_present(client):
     """Test that filter marks tokens as available when platform has native_token_id."""
     batch = BatchTokenPriceRequests(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gate3"
-version = "0.18.0"
+version = "0.19.0"
 description = "Gate API for web3 applications at Brave"
 authors = [
 ]


### PR DESCRIPTION
Adds Polkadot pricing support to the `/api/pricing/v1/getPrices` endpoint.

**Request:**
```sh
  curl -s -X POST 'http://127.0.0.1:8000/api/pricing/v1/getPrices?vs_currency=USD' \
    -H 'Content-Type: application/json' \
    -d '[
      {"address":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48","chain_id":"0x1","coin":"ETH"},
      {"chain_id":"polkadot_mainnet","coin":"DOT"}
    ]'
```

**Response:**

```json
  [
    {
      "coin": "ETH",
      "chain_id": "0x1",
      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
      "price": 0.999745,
      "percentage_change_24h": -0.0048509112488147686,
      "vs_currency": "USD",
      "cache_status": "MISS",
      "source": "coingecko"
    },
    {
      "coin": "DOT",
      "chain_id": "polkadot_mainnet",
      "address": null,
      "price": 1.32,
      "percentage_change_24h": 5.118018865440557,
      "vs_currency": "USD",
      "cache_status": "MISS",
      "source": "coingecko"
    }
  ]
```