### PR TITLE
Token Registry Resilience - Part I

### DIFF
--- a/app/api/common/models.py
+++ b/app/api/common/models.py
@@ -308,7 +308,7 @@ class TokenInfo(BaseModel):
     decimals: int = Field(..., description="Token decimals")
     logo: str | None = Field(None, description="Token logo URL")
     sources: list[TokenSource] = Field(..., description="Token sources")
-    token_type: TokenType = Field(..., description="Token type")
+    token_type: TokenType = Field(default=TokenType.UNKNOWN, description="Token type")
     near_intents_asset_id: str | None = Field(None, description="NEAR Intents asset ID")
 
     @property

--- a/app/api/tokens/manager.py
+++ b/app/api/tokens/manager.py
@@ -518,18 +518,3 @@ class TokenManager:
         result = await index.search(q)
 
         return cls._as_response(result, query, offset, limit)
-
-    @staticmethod
-    async def mock_fetch_from_blockchain(
-        coin: Coin, chain_id: str, address: str
-    ) -> TokenInfo | None:
-        return TokenInfo(
-            coin=coin,
-            chain_id=chain_id.lower(),
-            address=address,
-            name="Mock Token",
-            symbol="MTK",
-            decimals=18,
-            logo="https://example.com/mock-logo.png",
-            sources=[TokenSource.UNKNOWN],
-        )

--- a/app/api/tokens/manager.py
+++ b/app/api/tokens/manager.py
@@ -315,6 +315,17 @@ class TokenManager:
             logger.error("Error retrieving token: %s", e)
             return None
 
+    @staticmethod
+    def _coerce_token_type(raw: str | None) -> TokenType:
+        """Map a missing or unrecognized stored token_type to UNKNOWN."""
+        try:
+            return TokenType(raw) if raw else TokenType.UNKNOWN
+        except ValueError:
+            logger.warning(
+                "Unrecognized token_type %r in registry; defaulting to UNKNOWN", raw
+            )
+            return TokenType.UNKNOWN
+
     @classmethod
     def _build_key(cls, coin: Coin, chain_id: str, address: str | None = None) -> str:
         return ":".join(
@@ -344,8 +355,10 @@ class TokenManager:
 
         return token_data
 
-    @staticmethod
-    def _parse_token_from_redis_data(key: str, token_data: dict[str, str]) -> TokenInfo:
+    @classmethod
+    def _parse_token_from_redis_data(
+        cls, key: str, token_data: dict[str, str]
+    ) -> TokenInfo:
         # Parse the key to extract coin and chain_id (but not address, since it's lowercased in the key)
         key_parts = key.decode("utf-8") if isinstance(key, bytes) else key
         _, coin_str, chain_id, _ = key_parts.split(":", 3)
@@ -362,7 +375,7 @@ class TokenManager:
             decimals=int(token_data["decimals"]),
             logo=token_data.get("logo") or None,
             sources=json.loads(token_data.get("sources", "[]")),
-            token_type=TokenType(token_data["token_type"]),
+            token_type=cls._coerce_token_type(token_data.get("token_type")),
             near_intents_asset_id=token_data.get("near_intents_asset_id") or None,
         )
 
@@ -378,9 +391,9 @@ class TokenManager:
         except Exception as e:
             logger.error("Error adding token: %s", e)
 
-    @staticmethod
+    @classmethod
     def _as_response(
-        result, query: str, offset: int, limit: int
+        cls, result, query: str, offset: int, limit: int
     ) -> TokenSearchResponse:
         results = []
         for doc in result.docs:
@@ -396,7 +409,7 @@ class TokenManager:
                 decimals=int(doc.decimals),
                 logo=doc.logo,
                 sources=json.loads(doc.sources),
-                token_type=TokenType(doc.token_type),
+                token_type=cls._coerce_token_type(getattr(doc, "token_type", None)),
                 near_intents_asset_id=doc.near_intents_asset_id or None,
             )
 

--- a/app/api/tokens/routes.py
+++ b/app/api/tokens/routes.py
@@ -22,31 +22,12 @@ async def get_token_info(
     chain_id: str = Query(..., description=CHAIN_ID_DESCRIPTION),
     address: str | None = Query(None, description=ADDRESS_DESCRIPTION),
 ):
-    try:
-        # First try to get from Redis
-        token_info = await TokenManager.get(
-            coin=coin, chain_id=chain_id, address=address
-        )
+    token_info = await TokenManager.get(coin=coin, chain_id=chain_id, address=address)
 
-        if token_info:
-            return token_info
-
-        # If not found, try to fetch from blockchain (mock for now)
-        blockchain_token = await TokenManager.mock_fetch_from_blockchain(
-            coin, chain_id, address
-        )
-
-        if blockchain_token:
-            # Store the token in Redis for future requests
-            await TokenManager.add(blockchain_token)
-            return blockchain_token
-
-        # Token not found anywhere
+    if token_info is None:
         raise HTTPException(status_code=404, detail="Token not found")
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+    return token_info
 
 
 @router.get("/v1/list", response_model=list[TokenInfo])

--- a/app/api/tokens/test_manager.py
+++ b/app/api/tokens/test_manager.py
@@ -789,3 +789,72 @@ async def test_refresh_with_lifi_data(cache):
     assert result.symbol == "LIFI"
     assert result.decimals == 18
     assert TokenSource.LIFI in result.sources
+
+
+@pytest.mark.asyncio
+async def test_get_token_missing_token_type_defaults_to_unknown(cache):
+    """A legacy record written before token_type existed must still parse."""
+    redis_client = cache.get_client.return_value.__aenter__.return_value
+    address = "EPeUFDgHRxs9xxEPVaL6kfGQvCon7jmAWKVUHuux1Tpz"
+    key = f"token:sol:0x65:{address.lower()}"
+
+    await redis_client.hset(
+        key,
+        mapping={
+            "coin": "SOL",
+            "chain_id": "0x65",
+            "address": address,
+            "name": "Basic Attention Token (Portal)",
+            "symbol": "BAT",
+            "decimals": "8",
+            "logo": "",
+            "sources": json.dumps([TokenSource.COINGECKO.value]),
+            # token_type intentionally absent (pre-migration record)
+        },
+    )
+
+    result = await TokenManager.get(Chain.SOLANA.coin, Chain.SOLANA.chain_id, address)
+
+    assert result is not None
+    assert result.symbol == "BAT"
+    assert result.token_type == TokenType.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_get_token_invalid_token_type_defaults_to_unknown(cache):
+    redis_client = cache.get_client.return_value.__aenter__.return_value
+    address = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    key = f"token:sol:0x65:{address.lower()}"
+
+    await redis_client.hset(
+        key,
+        mapping={
+            "coin": "SOL",
+            "chain_id": "0x65",
+            "address": address,
+            "name": "USD Coin",
+            "symbol": "USDC",
+            "decimals": "6",
+            "logo": "",
+            "sources": json.dumps([TokenSource.COINGECKO.value]),
+            "token_type": "NOT_A_REAL_TYPE",
+        },
+    )
+
+    result = await TokenManager.get(Chain.SOLANA.coin, Chain.SOLANA.chain_id, address)
+
+    assert result is not None
+    assert result.token_type == TokenType.UNKNOWN
+
+
+def test_token_info_token_type_defaults_to_unknown():
+    token = TokenInfo(
+        coin=Coin.SOL,
+        chain_id="0x65",
+        name="Mock Token",
+        symbol="MTK",
+        decimals=9,
+        sources=[TokenSource.UNKNOWN],
+    )
+
+    assert token.token_type == TokenType.UNKNOWN

--- a/app/api/tokens/test_routes.py
+++ b/app/api/tokens/test_routes.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.common.models import Coin, TokenInfo, TokenSource, TokenType
+from app.main import app
+
+ADDRESS = "EPeUFDgHRxs9xxEPVaL6kfGQvCon7jmAWKVUHuux1Tpz"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_get_token_returns_404_when_not_in_registry(client):
+    with patch(
+        "app.api.tokens.routes.TokenManager.get",
+        new=AsyncMock(return_value=None),
+    ):
+        response = client.get(
+            "/api/tokens/v1/get",
+            params={"coin": "SOL", "chain_id": "0x65", "address": ADDRESS},
+        )
+
+    assert response.status_code == 404
+
+
+def test_get_token_returns_token_when_present(client):
+    token = TokenInfo(
+        coin=Coin.SOL,
+        chain_id="0x65",
+        address=ADDRESS,
+        name="Basic Attention Token (Portal)",
+        symbol="BAT",
+        decimals=8,
+        sources=[TokenSource.COINGECKO],
+        token_type=TokenType.SPL_TOKEN,
+    )
+
+    with patch(
+        "app.api.tokens.routes.TokenManager.get",
+        new=AsyncMock(return_value=token),
+    ):
+        response = client.get(
+            "/api/tokens/v1/get",
+            params={"coin": "SOL", "chain_id": "0x65", "address": ADDRESS},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["symbol"] == "BAT"
+    assert response.json()["token_type"] == "SPL_TOKEN"


### PR DESCRIPTION
* [fix(tokens): return 404 on cache miss instead of fabricating a token](https://github.com/brave/gate3/commit/23224f9c72403686b9d039685927544e89867a5b)
* [fix(tokens): tolerate missing/invalid token_type in registry records](https://github.com/brave/gate3/commit/04dec9041fdfe2a2bd47592ee3e1f0e4c09d5061)