### PR TITLE
Token Registry Resilience - Part II

### DIFF
--- a/app/api/tokens/manager.py
+++ b/app/api/tokens/manager.py
@@ -16,10 +16,20 @@ logger = logging.getLogger(__name__)
 
 TokenRegistry = dict[str, dict[str, str]]
 
+# Bump whenever the stored shape of a token record changes (a new required
+# field, a renamed field, etc.) so running instances reseed the registry on
+# their next startup instead of serving records the current code can't parse.
+TOKEN_SCHEMA_VERSION = "1"
+
 
 class TokenManager:
     key_prefix = "token"
     index_name = "token_idx"
+
+    # Metadata keys live outside the "token:*" namespace so _clear_tokens and
+    # the search index never touch them.
+    schema_version_key = "token_meta:schema_version"
+    reseed_lock_key = "token_meta:reseed_lock"
 
     # Pre-computed chain lookup for O(1) access
     _chain_lookup = {chain.chain_id: chain for chain in Chain}
@@ -120,6 +130,56 @@ class TokenManager:
             # Create index and execute atomically
             await cls.create_index()
             await pipe.execute()
+
+            # Record the schema version the registry was written with.
+            await redis_client.set(cls.schema_version_key, TOKEN_SCHEMA_VERSION)
+
+    @classmethod
+    async def is_empty(cls) -> bool:
+        """Return True if the registry contains no token records."""
+        async with Cache.get_client() as redis_client:
+            cursor = 0
+            while True:
+                cursor, keys = await redis_client.scan(
+                    cursor, match=f"{cls.key_prefix}:*", count=100
+                )
+                if keys:
+                    return False
+                if cursor == 0:
+                    return True
+
+    @classmethod
+    async def _is_stale(cls) -> bool:
+        """The registry needs reseeding if it is empty or schema-outdated."""
+        if await cls.is_empty():
+            return True
+
+        async with Cache.get_client() as redis_client:
+            stored = await redis_client.get(cls.schema_version_key)
+        if isinstance(stored, bytes):
+            stored = stored.decode()
+        return stored != TOKEN_SCHEMA_VERSION
+
+    @classmethod
+    async def refresh_if_stale(cls) -> bool:
+        """Reseed the registry on cold start or after a schema bump.
+
+        Makes the registry self-healing: a fresh/wiped Redis or a schema change
+        no longer requires a manual admin refresh before swaps work. A short
+        Redis lock ensures only one replica reseeds when many boot at once.
+
+        Returns True if this instance performed the reseed.
+        """
+        if not await cls._is_stale():
+            return False
+
+        async with Cache.get_client() as redis_client:
+            acquired = await redis_client.set(cls.reseed_lock_key, "1", nx=True, ex=300)
+        if not acquired:
+            return False
+
+        await cls.refresh()
+        return True
 
     @classmethod
     async def _clear_tokens(cls, pipe) -> None:

--- a/app/api/tokens/test_manager.py
+++ b/app/api/tokens/test_manager.py
@@ -10,7 +10,7 @@ import respx
 
 from app.api.common.models import Chain, Coin, TokenInfo, TokenSource, TokenType
 from app.api.tokens.contants import SPL_TOKEN_2022_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID
-from app.api.tokens.manager import TokenManager
+from app.api.tokens.manager import TOKEN_SCHEMA_VERSION, TokenManager
 
 
 class AsyncFakeRedis(fakeredis.FakeAsyncRedis):
@@ -858,3 +858,76 @@ def test_token_info_token_type_defaults_to_unknown():
     )
 
     assert token.token_type == TokenType.UNKNOWN
+
+
+def _ingestion_patches():
+    return (
+        patch.object(TokenManager, "create_index"),
+        patch.object(TokenManager, "ingest_from_coingecko"),
+        patch.object(TokenManager, "ingest_from_jupiter"),
+        patch.object(TokenManager, "ingest_from_near_intents"),
+        patch.object(TokenManager, "ingest_from_lifi"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_writes_schema_version(cache):
+    redis_client = cache.get_client.return_value.__aenter__.return_value
+
+    create_index, coingecko, jupiter, near_intents, lifi = _ingestion_patches()
+    with create_index, coingecko, jupiter, near_intents, lifi:
+        await TokenManager.refresh()
+
+    stored = await redis_client.get(TokenManager.schema_version_key)
+    if isinstance(stored, bytes):
+        stored = stored.decode()
+    assert stored == TOKEN_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_stale_reseeds_when_empty(cache):
+    create_index, coingecko, jupiter, near_intents, lifi = _ingestion_patches()
+    with create_index, coingecko, jupiter, near_intents, lifi:
+        performed = await TokenManager.refresh_if_stale()
+
+    assert performed is True
+    assert await TokenManager.get(Chain.SOLANA.coin, Chain.SOLANA.chain_id, None)
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_stale_noop_when_current(cache, sample_token_info):
+    redis_client = cache.get_client.return_value.__aenter__.return_value
+    await TokenManager.add(sample_token_info)
+    await redis_client.set(TokenManager.schema_version_key, TOKEN_SCHEMA_VERSION)
+
+    with patch.object(TokenManager, "refresh", new=AsyncMock()) as mock_refresh:
+        performed = await TokenManager.refresh_if_stale()
+
+    assert performed is False
+    mock_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_stale_reseeds_on_schema_bump(cache, sample_token_info):
+    redis_client = cache.get_client.return_value.__aenter__.return_value
+    await TokenManager.add(sample_token_info)
+    await redis_client.set(TokenManager.schema_version_key, "0")
+
+    with patch.object(TokenManager, "refresh", new=AsyncMock()) as mock_refresh:
+        performed = await TokenManager.refresh_if_stale()
+
+    assert performed is True
+    mock_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_stale_skips_when_another_replica_holds_lock(cache):
+    redis_client = cache.get_client.return_value.__aenter__.return_value
+    # Registry is empty (stale), but another replica already owns the lock.
+    await redis_client.set(TokenManager.reseed_lock_key, "1")
+
+    with patch.object(TokenManager, "refresh", new=AsyncMock()) as mock_refresh:
+        performed = await TokenManager.refresh_if_stale()
+
+    assert performed is False
+    mock_refresh.assert_not_called()

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import subprocess
 from contextlib import asynccontextmanager
 
@@ -18,9 +20,12 @@ from app.api.oauth.routes import router as oauth_router
 from app.api.pricing.routes import router as pricing_router
 from app.api.swap.routes import router as swap_router
 from app.api.swap.routes import setup_swap_error_handler
+from app.api.tokens.manager import TokenManager
 from app.api.tokens.routes import router as tokens_router
 from app.config import settings
 from app.core.cache import Cache
+
+logger = logging.getLogger(__name__)
 
 version = subprocess.run(
     ["poetry", "version", "--short"], capture_output=True, text=True, check=True
@@ -48,9 +53,25 @@ async def lifespan_metrics(app: FastAPI):
     yield
 
 
+async def _reseed_tokens_if_stale():
+    try:
+        if await TokenManager.refresh_if_stale():
+            logger.info("Token registry was stale; reseeded on startup")
+    except Exception:
+        logger.exception("Failed to reseed token registry on startup")
+
+
+@asynccontextmanager
+async def lifespan_tokens(app: FastAPI):
+    # Reseed in the background so a cold/stale Redis neither blocks startup nor
+    # crashes the app when an upstream token source is briefly unavailable.
+    app.state.token_seed_task = asyncio.create_task(_reseed_tokens_if_stale())
+    yield
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    async with lifespan_cache(app), lifespan_metrics(app):
+    async with lifespan_cache(app), lifespan_tokens(app), lifespan_metrics(app):
         yield
 
 


### PR DESCRIPTION
Token registry was never reseeded automatically. it was populated once and only refreshed via the manual `_admin/refresh` route. So a wiped Redis, or a record-shape change that left existing records unparseable, kept breaking swaps until someone refreshed by hand.

Resolves https://github.com/brave/gate3/issues/291
