### PR TITLE
feat(pricing): support Polkadot Asset Hub token prices

### DIFF
--- a/app/api/common/models.py
+++ b/app/api/common/models.py
@@ -228,6 +228,18 @@ class Chain(Enum):
         symbol="DOT",
         decimals=10,
     )
+    POLKADOT_ASSET_HUB = _c(
+        coin=Coin.DOT,
+        chain_id="polkadot_asset_hub",
+        simplehash_id="polkadot-asset-hub",
+        alchemy_id="polkadot-asset-hub-mainnet",
+        near_intents_id=None,
+        has_nft_support=False,
+        name="Polkadot Asset Hub",
+        native_asset_name="Polkadot",
+        symbol="DOT",
+        decimals=10,
+    )
 
     def __getattr__(self, name):
         """Delegate attribute access to the chain info"""

--- a/app/api/pricing/coingecko.py
+++ b/app/api/pricing/coingecko.py
@@ -22,6 +22,15 @@ from .utils import chunk_sequence
 
 logger = logging.getLogger(__name__)
 
+# CoinGecko platform ids that don't carry a numeric chain_identifier and must be
+# mapped to a specific chain. CoinGecko groups Polkadot ecosystem assets (e.g.
+# USDC, keyed by Asset Hub asset ids) under a single "polkadot" platform, so it
+# maps to Asset Hub where those assets actually live.
+_COINGECKO_PLATFORM_OVERRIDES = {
+    "solana": Chain.SOLANA,
+    "polkadot": Chain.POLKADOT_ASSET_HUB,
+}
+
 
 class CoinGeckoClient:
     def __init__(self):
@@ -176,7 +185,9 @@ class CoinGeckoClient:
         elif chain == Chain.ZCASH:
             return "zcash"
 
-        elif chain == Chain.POLKADOT:
+        elif (
+            chain in (Chain.POLKADOT, Chain.POLKADOT_ASSET_HUB) and not request.address
+        ):
             return "polkadot"
 
         elif chain == Chain.SOLANA and not request.address:
@@ -190,8 +201,11 @@ class CoinGeckoClient:
 
             return None
 
-        # EVM and Solana tokens
-        elif request.coin in [Coin.SOL, Coin.ETH] and request.address:
+        # EVM, Solana, and Polkadot Asset Hub tokens. Relay-chain Polkadot only
+        # supports native DOT, so token-by-address is limited to Asset Hub.
+        elif request.address and (
+            request.coin in [Coin.SOL, Coin.ETH] or chain == Chain.POLKADOT_ASSET_HUB
+        ):
             return coin_map.get(request.chain_id, {}).get(request.address.lower())
 
         return None
@@ -225,13 +239,21 @@ class CoinGeckoClient:
             coin_map = {}
             for item in data:
                 for platform_id, contract_address in item["platforms"].items():
-                    if platform_id in platform_map:
+                    if platform_id in platform_map and contract_address:
                         chain_id = platform_map[platform_id].chain_id
-                        if chain_id not in coin_map:
-                            coin_map[chain_id] = {}
-                        coin_map[chain_id][contract_address.lower()] = item[
-                            "id"
-                        ].lower()
+
+                        # Asset Hub assets are identified by integer asset IDs.
+                        # CoinGecko sometimes mistags EVM-style addresses under its
+                        # "polkadot" platform, so keep only numeric asset IDs there.
+                        if (
+                            chain_id == Chain.POLKADOT_ASSET_HUB.chain_id
+                            and not contract_address.isdigit()
+                        ):
+                            continue
+
+                        coin_map.setdefault(chain_id, {})[contract_address.lower()] = (
+                            item["id"].lower()
+                        )
 
             # Cache in Redis
             await CoinMapCache.set(coin_map)
@@ -251,8 +273,8 @@ class CoinGeckoClient:
             platform_map = {}
             for item in data:
                 chain_id = None
-                if item["id"] == "solana":
-                    chain_id = Chain.SOLANA.chain_id
+                if override := _COINGECKO_PLATFORM_OVERRIDES.get(item["id"]):
+                    chain_id = override.chain_id
                 elif item["chain_identifier"]:
                     chain_id = hex(item["chain_identifier"])
 

--- a/app/api/pricing/coingecko.py
+++ b/app/api/pricing/coingecko.py
@@ -206,7 +206,9 @@ class CoinGeckoClient:
         elif request.address and (
             request.coin in [Coin.SOL, Coin.ETH] or chain == Chain.POLKADOT_ASSET_HUB
         ):
-            return coin_map.get(request.chain_id, {}).get(request.address.lower())
+            return coin_map.get(request.chain_id.lower(), {}).get(
+                request.address.lower()
+            )
 
         return None
 
@@ -241,6 +243,8 @@ class CoinGeckoClient:
                 for platform_id, contract_address in item["platforms"].items():
                     if platform_id in platform_map and contract_address:
                         chain_id = platform_map[platform_id].chain_id
+                        if chain_id is None:
+                            continue
 
                         # Asset Hub assets are identified by integer asset IDs.
                         # CoinGecko sometimes mistags EVM-style addresses under its

--- a/app/api/pricing/tests/test_coingecko.py
+++ b/app/api/pricing/tests/test_coingecko.py
@@ -302,6 +302,65 @@ async def test_get_coin_map_maps_asset_hub_assets_and_skips_empty(
 
 
 @pytest.mark.asyncio
+async def test_get_coin_map_skips_platforms_without_chain_id(client, mock_httpx_client):
+    """Platforms with no resolved chain_id must not create a null key in the coin map."""
+    platform_map = {
+        "ethereum": CoingeckoPlatform(
+            id="ethereum", chain_id="0x1", native_token_id="ethereum"
+        ),
+        "near-protocol": CoingeckoPlatform(
+            id="near-protocol", chain_id=None, native_token_id="near"
+        ),
+    }
+    mock_response = AsyncMock()
+    mock_response.json = lambda: [
+        {
+            "id": "usd-coin",
+            "symbol": "usdc",
+            "platforms": {"ethereum": "0xA0b8", "near-protocol": "usdc.near"},
+        },
+    ]
+    mock_response.raise_for_status = lambda: None
+    mock_httpx_client.get.return_value = mock_response
+
+    with (
+        patch(
+            "app.api.pricing.coingecko.CoinMapCache.get",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("app.api.pricing.coingecko.CoinMapCache.set", new_callable=AsyncMock),
+    ):
+        coin_map = await client.get_coin_map(platform_map)
+
+    assert None not in coin_map
+    assert coin_map["0x1"] == {"0xa0b8": "usd-coin"}
+
+
+@pytest.mark.asyncio
+async def test_filter_token_lookup_is_case_insensitive_on_chain_id(client):
+    """A mixed-case chain_id still resolves against the lowercase-keyed coin map."""
+    batch = BatchTokenPriceRequests(
+        requests=[
+            TokenPriceRequest(coin=Coin.ETH, chain_id="0X1", address="0xABC"),
+        ],
+        vs_currency=VsCurrency.USD,
+    )
+
+    with (
+        patch.object(client, "get_platform_map") as mock_platform_map,
+        patch.object(client, "get_coin_map") as mock_coin_map,
+    ):
+        mock_platform_map.return_value = {}
+        mock_coin_map.return_value = {"0x1": {"0xabc": "some-token"}}
+
+        available, unavailable = await client.filter(batch)
+
+        assert available.size() == 1
+        assert unavailable.is_empty()
+
+
+@pytest.mark.asyncio
 async def test_filter_excludes_relay_chain_polkadot_token(client):
     """Relay-chain Polkadot supports only native DOT; a token address is unavailable."""
     batch = BatchTokenPriceRequests(

--- a/app/api/pricing/tests/test_coingecko.py
+++ b/app/api/pricing/tests/test_coingecko.py
@@ -171,6 +171,202 @@ async def test_filter_includes_native_polkadot(client):
 
 
 @pytest.mark.asyncio
+async def test_filter_includes_native_polkadot_asset_hub(client):
+    """Native DOT on Polkadot Asset Hub is available on CoinGecko without platform/coin maps."""
+    batch = BatchTokenPriceRequests(
+        requests=[
+            TokenPriceRequest(
+                coin=Chain.POLKADOT_ASSET_HUB.coin,
+                chain_id=Chain.POLKADOT_ASSET_HUB.chain_id,
+                address=None,
+            ),
+        ],
+        vs_currency=VsCurrency.USD,
+    )
+
+    with (
+        patch.object(client, "get_platform_map") as mock_platform_map,
+        patch.object(client, "get_coin_map") as mock_coin_map,
+    ):
+        mock_platform_map.return_value = {}
+        mock_coin_map.return_value = {}
+
+        available, unavailable = await client.filter(batch)
+
+        assert available.size() == 1
+        assert unavailable.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_get_prices_native_polkadot_asset_hub(client, mock_httpx_client):
+    """Native DOT on Polkadot Asset Hub is priced via the 'polkadot' CoinGecko id."""
+    batch = BatchTokenPriceRequests(
+        requests=[
+            TokenPriceRequest(
+                coin=Chain.POLKADOT_ASSET_HUB.coin,
+                chain_id=Chain.POLKADOT_ASSET_HUB.chain_id,
+                address=None,
+            ),
+        ],
+        vs_currency=VsCurrency.USD,
+    )
+
+    with (
+        patch("app.api.pricing.coingecko.CoingeckoPriceCache.get") as mock_cache,
+        patch(
+            "app.api.pricing.coingecko.CoingeckoPriceCache.set", new_callable=AsyncMock
+        ),
+        patch.object(client, "get_platform_map") as mock_platform_map,
+        patch.object(client, "get_coin_map") as mock_coin_map,
+    ):
+        mock_cache.return_value = ([], batch)
+        mock_platform_map.return_value = {}
+        mock_coin_map.return_value = {}
+
+        mock_response = AsyncMock()
+        mock_response.json = lambda: {"polkadot": {"usd": 4.2, "usd_24h_change": 1.5}}
+        mock_response.raise_for_status = lambda: None
+        mock_httpx_client.get.return_value = mock_response
+
+        results = await client.get_prices(batch)
+
+    assert len(results) == 1
+    assert results[0].price == 4.2
+    assert results[0].coin == Chain.POLKADOT_ASSET_HUB.coin
+    assert results[0].chain_id == Chain.POLKADOT_ASSET_HUB.chain_id
+    assert results[0].source == "coingecko"
+
+
+@pytest.mark.asyncio
+async def test_get_platform_map_maps_polkadot_to_asset_hub(client, mock_httpx_client):
+    """CoinGecko's 'polkadot' platform is mapped to our Asset Hub chain."""
+    mock_response = AsyncMock()
+    mock_response.json = lambda: [
+        {"id": "polkadot", "chain_identifier": None, "native_coin_id": "polkadot"},
+        {"id": "ethereum", "chain_identifier": 1, "native_coin_id": "ethereum"},
+    ]
+    mock_response.raise_for_status = lambda: None
+    mock_httpx_client.get.return_value = mock_response
+
+    with (
+        patch(
+            "app.api.pricing.coingecko.PlatformMapCache.get",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("app.api.pricing.coingecko.PlatformMapCache.set", new_callable=AsyncMock),
+    ):
+        platform_map = await client.get_platform_map()
+
+    assert platform_map["polkadot"].chain_id == Chain.POLKADOT_ASSET_HUB.chain_id
+    assert platform_map["polkadot"].native_token_id == "polkadot"
+
+
+@pytest.mark.asyncio
+async def test_get_coin_map_maps_asset_hub_assets_and_skips_empty(
+    client, mock_httpx_client
+):
+    """Asset Hub keeps numeric asset IDs only; empty and mistagged EVM addresses are skipped."""
+    platform_map = {
+        "polkadot": CoingeckoPlatform(
+            id="polkadot",
+            chain_id=Chain.POLKADOT_ASSET_HUB.chain_id,
+            native_token_id="polkadot",
+        ),
+    }
+    evm_address = "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d"
+    mock_response = AsyncMock()
+    mock_response.json = lambda: [
+        {"id": "usd-coin", "symbol": "usdc", "platforms": {"polkadot": "1337"}},
+        {"id": "acala", "symbol": "aca", "platforms": {"polkadot": ""}},
+        # CoinGecko occasionally mistags an EVM address under the polkadot platform.
+        {"id": "stafi", "symbol": "fis", "platforms": {"polkadot": evm_address}},
+    ]
+    mock_response.raise_for_status = lambda: None
+    mock_httpx_client.get.return_value = mock_response
+
+    with (
+        patch(
+            "app.api.pricing.coingecko.CoinMapCache.get",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("app.api.pricing.coingecko.CoinMapCache.set", new_callable=AsyncMock),
+    ):
+        coin_map = await client.get_coin_map(platform_map)
+
+    asset_hub = Chain.POLKADOT_ASSET_HUB.chain_id
+    assert coin_map[asset_hub] == {"1337": "usd-coin"}
+    assert "" not in coin_map[asset_hub]
+    assert evm_address not in coin_map[asset_hub]
+
+
+@pytest.mark.asyncio
+async def test_filter_excludes_relay_chain_polkadot_token(client):
+    """Relay-chain Polkadot supports only native DOT; a token address is unavailable."""
+    batch = BatchTokenPriceRequests(
+        requests=[
+            TokenPriceRequest(
+                coin=Chain.POLKADOT.coin,
+                chain_id=Chain.POLKADOT.chain_id,
+                address="1337",
+            ),
+        ],
+        vs_currency=VsCurrency.USD,
+    )
+
+    with (
+        patch.object(client, "get_platform_map") as mock_platform_map,
+        patch.object(client, "get_coin_map") as mock_coin_map,
+    ):
+        mock_platform_map.return_value = {}
+        # Even if a coin map existed for the relay chain, it must not be consulted.
+        mock_coin_map.return_value = {Chain.POLKADOT.chain_id: {"1337": "usd-coin"}}
+
+        available, unavailable = await client.filter(batch)
+
+        assert available.is_empty()
+        assert unavailable.size() == 1
+
+
+@pytest.mark.asyncio
+async def test_get_prices_polkadot_asset_hub_token(client, mock_httpx_client):
+    """A non-native Asset Hub asset (USDC, id 1337) is priced via its CoinGecko id."""
+    asset_hub = Chain.POLKADOT_ASSET_HUB.chain_id
+    batch = BatchTokenPriceRequests(
+        requests=[
+            TokenPriceRequest(coin=Coin.DOT, chain_id=asset_hub, address="1337"),
+        ],
+        vs_currency=VsCurrency.USD,
+    )
+
+    with (
+        patch("app.api.pricing.coingecko.CoingeckoPriceCache.get") as mock_cache,
+        patch(
+            "app.api.pricing.coingecko.CoingeckoPriceCache.set", new_callable=AsyncMock
+        ),
+        patch.object(client, "get_platform_map") as mock_platform_map,
+        patch.object(client, "get_coin_map") as mock_coin_map,
+    ):
+        mock_cache.return_value = ([], batch)
+        mock_platform_map.return_value = {}
+        mock_coin_map.return_value = {asset_hub: {"1337": "usd-coin"}}
+
+        mock_response = AsyncMock()
+        mock_response.json = lambda: {"usd-coin": {"usd": 1.0, "usd_24h_change": 0.1}}
+        mock_response.raise_for_status = lambda: None
+        mock_httpx_client.get.return_value = mock_response
+
+        results = await client.get_prices(batch)
+
+    assert len(results) == 1
+    assert results[0].price == 1.0
+    assert results[0].address == "1337"
+    assert results[0].chain_id == asset_hub
+    assert results[0].source == "coingecko"
+
+
+@pytest.mark.asyncio
 async def test_filter_includes_native_token_when_native_token_id_present(client):
     """Test that filter marks tokens as available when platform has native_token_id."""
     batch = BatchTokenPriceRequests(

--- a/app/api/tokens/test_manager.py
+++ b/app/api/tokens/test_manager.py
@@ -337,6 +337,46 @@ async def test_refresh_with_coingecko_data(cache):
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_refresh_ingests_polkadot_asset_hub_token(cache):
+    """Asset Hub assets (keyed by integer asset ID) are ingested as DOT tokens."""
+    coingecko_data = {
+        Chain.POLKADOT_ASSET_HUB.chain_id: {
+            "1337": {
+                "name": "USD Coin",
+                "symbol": "USDC",
+                "decimals": 6,
+                "logo": "https://example.com/usdc.png",
+            }
+        }
+    }
+    respx.get(
+        "https://raw.githubusercontent.com/brave/token-lists/refs/heads/main/data/v1/coingecko.json"
+    ).mock(return_value=httpx.Response(200, json=coingecko_data))
+
+    with (
+        patch.object(TokenManager, "create_index"),
+        patch.object(TokenManager, "ingest_from_jupiter"),
+        patch.object(TokenManager, "ingest_from_near_intents"),
+        patch.object(TokenManager, "ingest_from_lifi"),
+    ):
+        await TokenManager.refresh()
+
+        result = await TokenManager.get(
+            Chain.POLKADOT_ASSET_HUB.coin, Chain.POLKADOT_ASSET_HUB.chain_id, "1337"
+        )
+
+    assert result is not None
+    assert result.coin == Coin.DOT
+    assert result.chain_id == Chain.POLKADOT_ASSET_HUB.chain_id
+    assert result.address == "1337"
+    assert result.symbol == "USDC"
+    assert result.decimals == 6
+    assert result.token_type == TokenType.UNKNOWN
+    assert TokenSource.COINGECKO in result.sources
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_refresh_with_jupiter_data(cache):
     # Mock the Jupiter API responses
     jupiter_verified_data = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gate3"
-version = "0.19.0"
+version = "0.20.0"
 description = "Gate API for web3 applications at Brave"
 authors = [
 ]


### PR DESCRIPTION
Adds price support for **Polkadot Asset Hub** (`polkadot_asset_hub`), covering both native **DOT** and non-native assets (e.g. USDC), via CoinGecko.

**Request** (`?vs_currency=USD`):

```json
[
  {"coin":"DOT","chain_id":"polkadot_asset_hub","address":null},
  {"coin":"DOT","chain_id":"polkadot_asset_hub","address":"1337"},
  {"coin":"DOT","chain_id":"polkadot_mainnet","address":null},
  {"coin":"DOT","chain_id":"polkadot_mainnet","address":"1337"},
  {"coin":"DOT","chain_id":"polkadot_asset_hub","address":"0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d"}
]
```

**Response**:

| Request | Result |
|---|---|
| `polkadot_asset_hub` native DOT (`address: null`) | ✅ `$0.961417` |
| `polkadot_asset_hub` USDC (`address: "1337"`) | ✅ `$0.999749` |
| `polkadot_mainnet` native DOT (`address: null`) | ✅ `$0.961417` |
| `polkadot_mainnet` token (`address: "1337"`) | ⛔️ omitted: relay chain is native-DOT only |
| `polkadot_asset_hub` mistagged EVM addr | ⛔️ omitted: non-numeric asset ID filter dropped |