### PR TITLE
feat(phishing): add hash-prefix lookup API for Web3 safebrowsing

### DIFF
--- a/app/api/common/models.py
+++ b/app/api/common/models.py
@@ -21,6 +21,7 @@ class Tags(str, Enum):
     HEALTH = "Health"
     NFT = "NFT"
     OAUTH = "OAuth Proxy"
+    PHISHING = "Phishing"
     PRICING = "Pricing"
     SWAP = "Swap"
     TOKENS = "Tokens"

--- a/app/api/phishing/constants.py
+++ b/app/api/phishing/constants.py
@@ -1,0 +1,14 @@
+# Raw config from MetaMask eth-phishing-detect.
+PHISHING_LIST_URL = (
+    "https://raw.githubusercontent.com/MetaMask/eth-phishing-detect/"
+    "main/src/config.json"
+)
+
+# Bump whenever the stored Redis shape changes so instances self-heal on boot.
+PHISHING_SCHEMA_VERSION = "1"
+
+# Hash-prefix length: first 4 bytes → 8 hex characters.
+PREFIX_HEX_LENGTH = 8
+
+# Reasonable upper bound; clients typically send 1–6, occasionally ~10–11.
+MAX_PREFIXES_PER_REQUEST = 32

--- a/app/api/phishing/manager.py
+++ b/app/api/phishing/manager.py
@@ -1,0 +1,253 @@
+import hashlib
+import logging
+import time
+from collections import defaultdict
+from typing import Any
+
+from publicsuffixlist import PublicSuffixList
+
+from app.api.phishing.constants import (
+    PHISHING_LIST_URL,
+    PHISHING_SCHEMA_VERSION,
+    PREFIX_HEX_LENGTH,
+)
+from app.api.phishing.metrics import (
+    phishing_ingest_total,
+    phishing_list_entries,
+    phishing_list_hashes,
+    phishing_refresh_duration_seconds,
+)
+from app.core.cache import Cache
+from app.core.http import create_http_client
+
+logger = logging.getLogger(__name__)
+
+# Shared PSL instance; the bundled list is sufficient and avoids per-request I/O.
+_psl = PublicSuffixList()
+
+
+class PhishingManager:
+    key_prefix = "phish:prefix"
+    schema_version_key = "phish_meta:schema_version"
+    list_version_key = "phish_meta:list_version"
+    entry_count_key = "phish_meta:entry_count"
+    hash_count_key = "phish_meta:hash_count"
+    reseed_lock_key = "phish_meta:reseed_lock"
+
+    @staticmethod
+    def normalize(entry: str) -> str:
+        """Lowercase and strip trailing slashes / whitespace."""
+        return entry.strip().lower().rstrip("/")
+
+    @staticmethod
+    def hash_entry(normalized: str) -> str:
+        """Return the full 64-hex SHA-256 of a normalized entry."""
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def prefix_of(cls, full_hash: str) -> str:
+        return full_hash[:PREFIX_HEX_LENGTH]
+
+    @classmethod
+    def _prefix_key(cls, prefix: str) -> str:
+        return f"{cls.key_prefix}:{prefix.lower()}"
+
+    @classmethod
+    def expand_entries(cls, entry: str) -> set[str]:
+        """Normalize an entry and optionally add its PSL-bounded apex.
+
+        Path-containing entries are hashed as-is (no apex expansion). Shared-
+        hosting platforms on the PSL (e.g. vercel.app) never expand past the
+        tenant boundary because privatesuffix equals the listed host.
+        """
+        normalized = cls.normalize(entry)
+        if not normalized:
+            return set()
+
+        results = {normalized}
+
+        # Path entries: hash as-is; path expansion is client-side.
+        if "/" in normalized:
+            return results
+
+        apex = _psl.privatesuffix(normalized)
+        if apex and apex != normalized:
+            results.add(apex)
+
+        return results
+
+    @classmethod
+    def build_prefix_map(cls, entries: list[str]) -> dict[str, set[str]]:
+        """Map 8-hex prefixes → full SHA-256 hashes for all expanded entries."""
+        prefix_map: dict[str, set[str]] = defaultdict(set)
+        for entry in entries:
+            for candidate in cls.expand_entries(entry):
+                full_hash = cls.hash_entry(candidate)
+                prefix_map[cls.prefix_of(full_hash)].add(full_hash)
+        return prefix_map
+
+    @classmethod
+    def _extract_blocklist(cls, payload: Any) -> tuple[list[str], str]:
+        """Pull blocklist entries + version from config.json (old or new shape)."""
+        if isinstance(payload, list):
+            entries: list[str] = []
+            versions: list[str] = []
+            for cfg in payload:
+                if not isinstance(cfg, dict):
+                    continue
+                entries.extend(cls._blocklist_from_dict(cfg))
+                if "version" in cfg:
+                    versions.append(str(cfg["version"]))
+            version = ",".join(versions) if versions else "unknown"
+            return entries, version
+
+        if isinstance(payload, dict):
+            entries = cls._blocklist_from_dict(payload)
+            version = str(payload.get("version", "unknown"))
+            return entries, version
+
+        raise ValueError("Unexpected eth-phishing-detect config shape")
+
+    @staticmethod
+    def _blocklist_from_dict(cfg: dict[str, Any]) -> list[str]:
+        # Live config still uses "blacklist"; newer format uses "blocklist".
+        raw = cfg.get("blocklist")
+        if raw is None:
+            raw = cfg.get("blacklist")
+        if not isinstance(raw, list):
+            return []
+        return [item for item in raw if isinstance(item, str)]
+
+    @classmethod
+    async def fetch_blocklist(cls) -> tuple[list[str], str]:
+        async with create_http_client(timeout=60.0) as client:
+            response = await client.get(PHISHING_LIST_URL)
+            response.raise_for_status()
+            payload = response.json()
+        return cls._extract_blocklist(payload)
+
+    @classmethod
+    async def refresh(cls) -> dict[str, Any]:
+        """Clear and re-ingest the phishing hash index atomically."""
+        started = time.perf_counter()
+        try:
+            entries, list_version = await cls.fetch_blocklist()
+            prefix_map = cls.build_prefix_map(entries)
+            hash_count = sum(len(hashes) for hashes in prefix_map.values())
+
+            async with Cache.get_client() as redis_client:
+                pipe = redis_client.pipeline()
+                await cls._clear_prefix_keys(pipe)
+
+                for prefix, hashes in prefix_map.items():
+                    if hashes:
+                        pipe.sadd(cls._prefix_key(prefix), *hashes)
+
+                pipe.set(cls.schema_version_key, PHISHING_SCHEMA_VERSION)
+                pipe.set(cls.list_version_key, list_version)
+                pipe.set(cls.entry_count_key, str(len(entries)))
+                pipe.set(cls.hash_count_key, str(hash_count))
+                await pipe.execute()
+
+            phishing_list_entries.set(len(entries))
+            phishing_list_hashes.set(hash_count)
+            phishing_ingest_total.labels(status="success").inc()
+
+            logger.info(
+                "Phishing list refreshed: version=%s entries=%d hashes=%d prefixes=%d",
+                list_version,
+                len(entries),
+                hash_count,
+                len(prefix_map),
+            )
+            return {
+                "version": list_version,
+                "entry_count": len(entries),
+                "hash_count": hash_count,
+                "prefix_count": len(prefix_map),
+            }
+        except Exception:
+            phishing_ingest_total.labels(status="error").inc()
+            logger.exception("Failed to refresh phishing list")
+            raise
+        finally:
+            phishing_refresh_duration_seconds.observe(time.perf_counter() - started)
+
+    @classmethod
+    async def _clear_prefix_keys(cls, pipe) -> None:
+        async with Cache.get_client() as redis_client:
+            cursor = 0
+            while True:
+                cursor, keys = await redis_client.scan(
+                    cursor, match=f"{cls.key_prefix}:*", count=1_000
+                )
+                for key in keys:
+                    pipe.delete(key)
+                if cursor == 0:
+                    break
+
+    @classmethod
+    async def is_empty(cls) -> bool:
+        async with Cache.get_client() as redis_client:
+            cursor = 0
+            while True:
+                cursor, keys = await redis_client.scan(
+                    cursor, match=f"{cls.key_prefix}:*", count=100
+                )
+                if keys:
+                    return False
+                if cursor == 0:
+                    return True
+
+    @classmethod
+    async def _is_stale(cls) -> bool:
+        if await cls.is_empty():
+            return True
+
+        async with Cache.get_client() as redis_client:
+            stored = await redis_client.get(cls.schema_version_key)
+        if isinstance(stored, bytes):
+            stored = stored.decode()
+        return stored != PHISHING_SCHEMA_VERSION
+
+    @classmethod
+    async def refresh_if_stale(cls) -> bool:
+        """Reseed on cold start / schema bump. Returns True if this instance reseeds."""
+        if not await cls._is_stale():
+            return False
+
+        async with Cache.get_client() as redis_client:
+            acquired = await redis_client.set(cls.reseed_lock_key, "1", nx=True, ex=300)
+        if not acquired:
+            return False
+
+        await cls.refresh()
+        return True
+
+    @classmethod
+    async def get_list_version(cls) -> str:
+        async with Cache.get_client() as redis_client:
+            version = await redis_client.get(cls.list_version_key)
+        if isinstance(version, bytes):
+            version = version.decode()
+        return version or "unknown"
+
+    @classmethod
+    async def lookup(cls, prefixes: list[str]) -> dict[str, list[str]]:
+        """Return all full hashes sharing each submitted 8-hex prefix."""
+        if not prefixes:
+            return {}
+
+        async with Cache.get_client() as redis_client:
+            pipe = redis_client.pipeline()
+            for prefix in prefixes:
+                pipe.smembers(cls._prefix_key(prefix))
+            results = await pipe.execute()
+
+        matches: dict[str, list[str]] = {}
+        for prefix, members in zip(prefixes, results):
+            hashes = sorted(
+                m.decode() if isinstance(m, bytes) else m for m in (members or [])
+            )
+            matches[prefix.lower()] = hashes
+        return matches

--- a/app/api/phishing/metrics.py
+++ b/app/api/phishing/metrics.py
@@ -1,0 +1,45 @@
+"""Prometheus metrics for phishing list ingestion and lookup."""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+DURATION_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0)
+
+phishing_ingest_total = Counter(
+    "phishing_ingest_total",
+    "Phishing list ingestion attempts",
+    labelnames=["status"],
+)
+
+phishing_list_entries = Gauge(
+    "phishing_list_entries",
+    "Number of source blocklist entries from the last successful ingest",
+)
+
+phishing_list_hashes = Gauge(
+    "phishing_list_hashes",
+    "Number of unique full hashes stored after the last successful ingest",
+)
+
+phishing_refresh_duration_seconds = Histogram(
+    "phishing_refresh_duration_seconds",
+    "Duration of phishing list refresh operations",
+    buckets=DURATION_BUCKETS,
+)
+
+phishing_lookup_requests_total = Counter(
+    "phishing_lookup_requests_total",
+    "Phishing hash-prefix lookup requests",
+    labelnames=["status"],
+)
+
+phishing_lookup_duration_seconds = Histogram(
+    "phishing_lookup_duration_seconds",
+    "Duration of phishing hash-prefix lookups",
+    buckets=DURATION_BUCKETS,
+)
+
+phishing_lookup_prefixes = Histogram(
+    "phishing_lookup_prefixes",
+    "Number of hash prefixes per lookup request",
+    buckets=(1, 2, 4, 6, 8, 11, 16, 32),
+)

--- a/app/api/phishing/models.py
+++ b/app/api/phishing/models.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+class PhishingLookupResponse(BaseModel):
+    """Full-hash candidates for each submitted 4-byte prefix."""
+
+    version: str = Field(description="Ingested eth-phishing-detect list version")
+    matches: dict[str, list[str]] = Field(
+        description=(
+            "Map of requested 8-hex prefixes to full 64-hex SHA-256 hashes "
+            "sharing that prefix"
+        )
+    )
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )
+
+
+class PhishingRefreshResponse(BaseModel):
+    status: str
+    message: str
+    version: str | None = None
+    entry_count: int | None = None
+    hash_count: int | None = None
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )

--- a/app/api/phishing/routes.py
+++ b/app/api/phishing/routes.py
@@ -59,7 +59,7 @@ async def lookup_hashes(
             "Comma-separated 8-hex-char SHA-256 prefixes "
             "(first 4 bytes of each candidate hash)"
         ),
-        examples=["ab12cd34,ef567890"],
+        example="ab12cd34,ef567890",
     ),
 ):
     """Return all full hashes sharing each submitted prefix (k-anonymity lookup)."""
@@ -77,7 +77,7 @@ async def lookup_hashes(
     except Exception as e:
         status = "error"
         raise HTTPException(
-            status_code=500, detail=f"Failed to lookup phishing hashes: {e}"
+            status_code=500, detail=f"Failed to lookup phishing hashes: {str(e)}"
         ) from e
     finally:
         phishing_lookup_requests_total.labels(status=status).inc()
@@ -86,6 +86,8 @@ async def lookup_hashes(
 
 @router.get("/v1/_admin/refresh", response_model=PhishingRefreshResponse)
 async def admin_refresh_phishing_list():
+    # Same pattern as /api/tokens/v1/_admin/refresh: no in-app auth; access is
+    # gated by the Brave Services Key at the edge.
     try:
         result = await PhishingManager.refresh()
         return PhishingRefreshResponse(
@@ -97,5 +99,5 @@ async def admin_refresh_phishing_list():
         )
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Failed to refresh phishing list: {e}"
+            status_code=500, detail=f"Failed to refresh phishing list: {str(e)}"
         ) from e

--- a/app/api/phishing/routes.py
+++ b/app/api/phishing/routes.py
@@ -1,0 +1,101 @@
+import re
+import time
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.api.common.models import Tags
+from app.api.phishing.constants import MAX_PREFIXES_PER_REQUEST, PREFIX_HEX_LENGTH
+from app.api.phishing.manager import PhishingManager
+from app.api.phishing.metrics import (
+    phishing_lookup_duration_seconds,
+    phishing_lookup_prefixes,
+    phishing_lookup_requests_total,
+)
+from app.api.phishing.models import PhishingLookupResponse, PhishingRefreshResponse
+
+router = APIRouter(prefix="/api/phishing", tags=[Tags.PHISHING])
+
+_PREFIX_RE = re.compile(rf"^[0-9a-fA-F]{{{PREFIX_HEX_LENGTH}}}$")
+
+
+def _parse_prefixes(raw: str) -> list[str]:
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if not parts:
+        raise HTTPException(
+            status_code=400, detail="At least one hash prefix is required"
+        )
+    if len(parts) > MAX_PREFIXES_PER_REQUEST:
+        raise HTTPException(
+            status_code=400,
+            detail=f"At most {MAX_PREFIXES_PER_REQUEST} prefixes allowed per request",
+        )
+
+    invalid = [p for p in parts if not _PREFIX_RE.fullmatch(p)]
+    if invalid:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Malformed prefix(es): each must be exactly {PREFIX_HEX_LENGTH} "
+                f"hex characters; got {invalid}"
+            ),
+        )
+
+    # Preserve request order but dedupe for Redis round-trips.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for prefix in parts:
+        lower = prefix.lower()
+        if lower not in seen:
+            seen.add(lower)
+            ordered.append(lower)
+    return ordered
+
+
+@router.get("/v1/lookup", response_model=PhishingLookupResponse)
+async def lookup_hashes(
+    prefixes: str = Query(
+        ...,
+        description=(
+            "Comma-separated 8-hex-char SHA-256 prefixes "
+            "(first 4 bytes of each candidate hash)"
+        ),
+        examples=["ab12cd34,ef567890"],
+    ),
+):
+    """Return all full hashes sharing each submitted prefix (k-anonymity lookup)."""
+    started = time.perf_counter()
+    status = "success"
+    try:
+        parsed = _parse_prefixes(prefixes)
+        phishing_lookup_prefixes.observe(len(parsed))
+        matches = await PhishingManager.lookup(parsed)
+        version = await PhishingManager.get_list_version()
+        return PhishingLookupResponse(version=version, matches=matches)
+    except HTTPException:
+        status = "error"
+        raise
+    except Exception as e:
+        status = "error"
+        raise HTTPException(
+            status_code=500, detail=f"Failed to lookup phishing hashes: {e}"
+        ) from e
+    finally:
+        phishing_lookup_requests_total.labels(status=status).inc()
+        phishing_lookup_duration_seconds.observe(time.perf_counter() - started)
+
+
+@router.get("/v1/_admin/refresh", response_model=PhishingRefreshResponse)
+async def admin_refresh_phishing_list():
+    try:
+        result = await PhishingManager.refresh()
+        return PhishingRefreshResponse(
+            status="success",
+            message="Phishing list refreshed successfully",
+            version=result["version"],
+            entry_count=result["entry_count"],
+            hash_count=result["hash_count"],
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to refresh phishing list: {e}"
+        ) from e

--- a/app/api/phishing/test_manager.py
+++ b/app/api/phishing/test_manager.py
@@ -1,0 +1,137 @@
+from unittest.mock import patch
+
+import fakeredis
+import pytest
+import respx
+from httpx import Response
+
+from app.api.phishing.constants import PHISHING_LIST_URL, PHISHING_SCHEMA_VERSION
+from app.api.phishing.manager import PhishingManager
+
+
+@pytest.fixture
+def cache():
+    redis_client = fakeredis.FakeAsyncRedis(decode_responses=True)
+
+    with patch("app.api.phishing.manager.Cache") as mock_cache:
+        mock_cache.get_client.return_value.__aenter__.return_value = redis_client
+        mock_cache.get_client.return_value.__aexit__.return_value = None
+        yield redis_client
+
+
+class TestNormalizeAndHash:
+    def test_normalize_lowercases_and_strips(self):
+        assert PhishingManager.normalize("  Evil.COM/  ") == "evil.com"
+
+    def test_hash_is_sha256_hex(self):
+        full = PhishingManager.hash_entry("evil.com")
+        assert len(full) == 64
+        assert full == PhishingManager.hash_entry("evil.com")
+        assert PhishingManager.prefix_of(full) == full[:8]
+
+
+class TestExpandEntries:
+    def test_apex_expansion_for_subdomain(self):
+        expanded = PhishingManager.expand_entries("sub.evil.com")
+        assert expanded == {"sub.evil.com", "evil.com"}
+
+    def test_no_expansion_when_already_apex(self):
+        assert PhishingManager.expand_entries("evil.com") == {"evil.com"}
+
+    def test_shared_hosting_psl_does_not_over_expand(self):
+        # vercel.app is on the PSL; tenant boundary is evil.vercel.app itself.
+        assert PhishingManager.expand_entries("evil.vercel.app") == {"evil.vercel.app"}
+        assert PhishingManager.expand_entries("foo.github.io") == {"foo.github.io"}
+
+    def test_path_entries_are_not_apex_expanded(self):
+        entry = "ipfs.io/ipfs/QmExample"
+        assert PhishingManager.expand_entries(entry) == {"ipfs.io/ipfs/qmexample"}
+
+    def test_empty_after_normalize_returns_empty(self):
+        assert PhishingManager.expand_entries("   ///  ") == set()
+
+
+class TestBuildPrefixMap:
+    def test_buckets_by_prefix(self):
+        prefix_map = PhishingManager.build_prefix_map(["evil.com", "sub.evil.com"])
+        evil_hash = PhishingManager.hash_entry("evil.com")
+        sub_hash = PhishingManager.hash_entry("sub.evil.com")
+
+        assert evil_hash in prefix_map[evil_hash[:8]]
+        assert sub_hash in prefix_map[sub_hash[:8]]
+        # Apex expansion of sub.evil.com also contributes evil.com's hash.
+        assert evil_hash in prefix_map[evil_hash[:8]]
+
+
+class TestExtractBlocklist:
+    def test_legacy_blacklist_shape(self):
+        entries, version = PhishingManager._extract_blocklist(
+            {"version": 2, "blacklist": ["a.com", "b.com"], "whitelist": ["c.com"]}
+        )
+        assert entries == ["a.com", "b.com"]
+        assert version == "2"
+
+    def test_blocklist_preferred(self):
+        entries, version = PhishingManager._extract_blocklist(
+            {"version": 3, "blocklist": ["new.com"], "blacklist": ["old.com"]}
+        )
+        assert entries == ["new.com"]
+        assert version == "3"
+
+    def test_multi_config_array(self):
+        entries, version = PhishingManager._extract_blocklist(
+            [
+                {"name": "metamask", "version": 1, "blocklist": ["a.com"]},
+                {"name": "other", "version": 2, "blacklist": ["b.com"]},
+            ]
+        )
+        assert entries == ["a.com", "b.com"]
+        assert version == "1,2"
+
+
+@pytest.mark.asyncio
+async def test_refresh_and_lookup(cache):
+    config = {
+        "version": 42,
+        "blacklist": ["evil.com", "phish.example", "tenant.vercel.app"],
+    }
+
+    with respx.mock:
+        respx.get(PHISHING_LIST_URL).mock(return_value=Response(200, json=config))
+        result = await PhishingManager.refresh()
+
+    assert result["version"] == "42"
+    assert result["entry_count"] == 3
+    assert result["hash_count"] >= 3
+
+    evil_hash = PhishingManager.hash_entry("evil.com")
+    prefix = evil_hash[:8]
+    matches = await PhishingManager.lookup([prefix, "00000000"])
+    assert evil_hash in matches[prefix]
+    assert matches["00000000"] == []
+    assert await PhishingManager.get_list_version() == "42"
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_stale_reseeds_empty_store(cache):
+    config = {"version": 1, "blacklist": ["evil.com"]}
+
+    assert await PhishingManager.is_empty()
+
+    with respx.mock:
+        respx.get(PHISHING_LIST_URL).mock(return_value=Response(200, json=config))
+        assert await PhishingManager.refresh_if_stale() is True
+
+    assert not await PhishingManager.is_empty()
+    stored = await cache.get(PhishingManager.schema_version_key)
+    assert stored == PHISHING_SCHEMA_VERSION
+
+    # Second call should no-op.
+    assert await PhishingManager.refresh_if_stale() is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_stale_skips_when_lock_held(cache):
+    await cache.set(PhishingManager.reseed_lock_key, "1")
+    # Empty store is stale, but lock prevents reseed.
+    assert await PhishingManager.refresh_if_stale() is False

--- a/app/api/phishing/test_routes.py
+++ b/app/api/phishing/test_routes.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_lookup_returns_matches(client):
+    with (
+        patch(
+            "app.api.phishing.routes.PhishingManager.lookup",
+            new=AsyncMock(
+                return_value={
+                    "ab12cd34": ["ab12cd34" + "0" * 56],
+                    "ef567890": [],
+                }
+            ),
+        ),
+        patch(
+            "app.api.phishing.routes.PhishingManager.get_list_version",
+            new=AsyncMock(return_value="42"),
+        ),
+    ):
+        response = client.get(
+            "/api/phishing/v1/lookup",
+            params={"prefixes": "ab12cd34,ef567890"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == "42"
+    assert body["matches"]["ab12cd34"] == ["ab12cd34" + "0" * 56]
+    assert body["matches"]["ef567890"] == []
+
+
+def test_lookup_rejects_malformed_prefix(client):
+    response = client.get(
+        "/api/phishing/v1/lookup",
+        params={"prefixes": "ab12cd34,short"},
+    )
+    assert response.status_code == 400
+    assert "Malformed" in response.json()["detail"]
+
+
+def test_lookup_rejects_non_hex_prefix(client):
+    response = client.get(
+        "/api/phishing/v1/lookup",
+        params={"prefixes": "ghijklmn"},
+    )
+    assert response.status_code == 400
+
+
+def test_lookup_rejects_empty_prefixes(client):
+    response = client.get(
+        "/api/phishing/v1/lookup",
+        params={"prefixes": " , , "},
+    )
+    assert response.status_code == 400
+
+
+def test_admin_refresh_success(client):
+    with patch(
+        "app.api.phishing.routes.PhishingManager.refresh",
+        new=AsyncMock(
+            return_value={
+                "version": "7",
+                "entry_count": 100,
+                "hash_count": 120,
+                "prefix_count": 90,
+            }
+        ),
+    ):
+        response = client.get("/api/phishing/v1/_admin/refresh")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["version"] == "7"
+    assert body["entryCount"] == 100
+    assert body["hashCount"] == 120

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,8 @@ from app.api.nft.routes import (
     simplehash_router as simplehash_nfts_router,
 )
 from app.api.oauth.routes import router as oauth_router
+from app.api.phishing.manager import PhishingManager
+from app.api.phishing.routes import router as phishing_router
 from app.api.pricing.routes import router as pricing_router
 from app.api.swap.routes import router as swap_router
 from app.api.swap.routes import setup_swap_error_handler
@@ -64,6 +66,14 @@ async def _reseed_tokens_if_stale():
         logger.exception("Failed to reseed token registry on startup")
 
 
+async def _reseed_phishing_if_stale():
+    try:
+        if await PhishingManager.refresh_if_stale():
+            logger.info("Phishing hash index was stale; reseeded on startup")
+    except Exception:
+        logger.exception("Failed to reseed phishing hash index on startup")
+
+
 @asynccontextmanager
 async def lifespan_tokens(app: FastAPI):
     # Reseed in the background so a cold/stale Redis neither blocks startup nor
@@ -73,8 +83,19 @@ async def lifespan_tokens(app: FastAPI):
 
 
 @asynccontextmanager
+async def lifespan_phishing(app: FastAPI):
+    app.state.phishing_seed_task = asyncio.create_task(_reseed_phishing_if_stale())
+    yield
+
+
+@asynccontextmanager
 async def lifespan(app: FastAPI):
-    async with lifespan_cache(app), lifespan_tokens(app), lifespan_metrics(app):
+    async with (
+        lifespan_cache(app),
+        lifespan_tokens(app),
+        lifespan_phishing(app),
+        lifespan_metrics(app),
+    ):
         yield
 
 
@@ -86,6 +107,7 @@ app.include_router(base_router)
 app.include_router(pricing_router)
 app.include_router(nfts_router)
 app.include_router(tokens_router)
+app.include_router(phishing_router)
 app.include_router(oauth_router)
 app.include_router(swap_router)
 

--- a/app/main.py
+++ b/app/main.py
@@ -74,18 +74,34 @@ async def _reseed_phishing_if_stale():
         logger.exception("Failed to reseed phishing hash index on startup")
 
 
+async def _cancel_background_task(task: asyncio.Task | None) -> None:
+    if task is None:
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
 @asynccontextmanager
 async def lifespan_tokens(app: FastAPI):
     # Reseed in the background so a cold/stale Redis neither blocks startup nor
     # crashes the app when an upstream token source is briefly unavailable.
     app.state.token_seed_task = asyncio.create_task(_reseed_tokens_if_stale())
-    yield
+    try:
+        yield
+    finally:
+        await _cancel_background_task(app.state.token_seed_task)
 
 
 @asynccontextmanager
 async def lifespan_phishing(app: FastAPI):
     app.state.phishing_seed_task = asyncio.create_task(_reseed_phishing_if_stale())
-    yield
+    try:
+        yield
+    finally:
+        await _cancel_background_task(app.state.phishing_seed_task)
 
 
 @asynccontextmanager

--- a/poetry.lock
+++ b/poetry.lock
@@ -1111,6 +1111,22 @@ prometheus-client = ">=0.8.0,<1.0.0"
 starlette = ">=1.0.0,<2.0.0"
 
 [[package]]
+name = "publicsuffixlist"
+version = "1.0.2.20260716"
+description = "publicsuffixlist implement"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+files = [
+    {file = "publicsuffixlist-1.0.2.20260716-py2.py3-none-any.whl", hash = "sha256:b0e6e1d5b49ee0630e2fbb4c53040dfe3803cc29d95481e5331b601bba73aa78"},
+    {file = "publicsuffixlist-1.0.2.20260716.tar.gz", hash = "sha256:b021b7e1f7aa76cbd3c2a9748f2f1e688a931710340e6e106b5ef803227cb0e4"},
+]
+
+[package.extras]
+readme = ["pandoc"]
+update = ["requests"]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 description = "Data validation using Python type hints"
@@ -2283,4 +2299,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "93794ed7d8b7498efe2ed005ca8a306ccdaf3b62a28b632c89c119527d99ef2d"
+content-hash = "c3af8d36bca4035f3d878a1406fe9e9b94bd712802cd1ad9e212258927565f0f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "cachetools (>=7.1.1,<7.2.0)",
     "requests (>=2.32.4,<3.0.0)",
     "fakeredis[json] (>=2.30.1,<3.0.0)",
-    "sentry-sdk[fastapi] (>=2.38.0,<3.0.0)"
+    "sentry-sdk[fastapi] (>=2.38.0,<3.0.0)",
+    "publicsuffixlist (>=1.0.2.20260716,<2.0.0.0)"
 ]
 
 


### PR DESCRIPTION
Adds a privacy-preserving phishing lookup API so wallets can check connection requests against MetaMask's `eth-phishing-detect` blocklist without sending plaintext URLs to gate3.

Ingests the blocklist into Redis (normalize → SHA-256 → PSL apex expansion), buckets full hashes by 4-byte prefix, and serves k-anonymity lookups. Follows the TokenManager refresh/staleness pattern, with Prometheus metrics for ingest and lookup latency.

**Refresh list:**

```sh
curl -s 'http://localhost:8000/api/phishing/v1/_admin/refresh'
```

Response:

```sh
{
  "status": "success",
  "message": "Phishing list refreshed successfully",
  "version": "2",
  "entryCount": 107363,
  "hashCount": 108421
}
```

**Lookup by hash prefix:**

```sh
curl -s 'http://localhost:8000/api/phishing/v1/lookup?prefixes=a5821d84'
```

Response:

```sh
{
  "version": "2",
  "matches": {
    "a5821d84": [
      "a5821d8435392716848b1b570a64af44a33f0fd440570a94311e12c7cdcc2b18"
    ]
  }
}
```