### PR TITLE
feat(swap): request confidential intents on NEAR Intents quotes

### DIFF
--- a/app/api/swap/providers/near_intents/mocks.py
+++ b/app/api/swap/providers/near_intents/mocks.py
@@ -137,6 +137,7 @@ MOCK_QUOTE_REQUEST = {
     "recipient": "bc1qpjqsdj3qvfl4hzfa49p28ns9xkpl73cyg9exzn",
     "recipientType": "DESTINATION_CHAIN",
     "deadline": "2025-12-11T13:48:50.883000Z",
+    "confidentiality": "basic",
     "referral": "brave",
     "quoteWaitingTimeMs": 0,
 }

--- a/app/api/swap/providers/near_intents/models.py
+++ b/app/api/swap/providers/near_intents/models.py
@@ -22,6 +22,12 @@ class NearIntentsDepositMode(str, Enum):
     MEMO = "MEMO"
 
 
+class NearIntentsConfidentiality(str, Enum):
+    PUBLIC = "public"
+    BASIC = "basic"
+    ADVANCED = "advanced"
+
+
 class NearIntentsQuoteRequestBody(BaseModel):
     dry: bool = Field(default=False, description="Dry run flag")
     deposit_mode: NearIntentsDepositMode
@@ -38,6 +44,8 @@ class NearIntentsQuoteRequestBody(BaseModel):
     recipient: str
     recipient_type: str = Field(default="DESTINATION_CHAIN")
     deadline: str
+    # Only confidential intents are supported; transparent swaps are deprecated.
+    confidentiality: NearIntentsConfidentiality = NearIntentsConfidentiality.BASIC
     referral: str = Field(default="brave")
     quote_waiting_time_ms: int = Field(default=0)
 

--- a/app/api/swap/providers/near_intents/models.py
+++ b/app/api/swap/providers/near_intents/models.py
@@ -44,8 +44,11 @@ class NearIntentsQuoteRequestBody(BaseModel):
     recipient: str
     recipient_type: str = Field(default="DESTINATION_CHAIN")
     deadline: str
-    # Only confidential intents are supported; transparent swaps are deprecated.
-    confidentiality: NearIntentsConfidentiality = NearIntentsConfidentiality.BASIC
+    # Default to BASIC confidentiality; "public" (transparent) swaps are deprecated.
+    confidentiality: NearIntentsConfidentiality = Field(
+        default=NearIntentsConfidentiality.BASIC,
+        description="Requested intent confidentiality level (defaults to BASIC).",
+    )
     referral: str = Field(default="brave")
     quote_waiting_time_ms: int = Field(default=0)
 

--- a/app/api/swap/providers/near_intents/test_client.py
+++ b/app/api/swap/providers/near_intents/test_client.py
@@ -317,6 +317,8 @@ async def test_get_indicative_route_success(
     call_args = mock_httpx_client.post.call_args
     assert call_args[0][0] == "https://1click.chaindefuser.com/v0/quote"
     assert call_args[1]["json"]["dry"] is True
+    # Transparent swaps are deprecated; every quote must be confidential
+    assert call_args[1]["json"]["confidentiality"] == "basic"
 
     # Verify response is a list with one route
     assert len(routes) == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gate3"
-version = "0.20.0"
+version = "0.21.0"
 description = "Gate API for web3 applications at Brave"
 authors = [
 ]


### PR DESCRIPTION
### What

Adds a `confidentiality` field to the NEAR Intents quote request body, defaulting to `basic`. Transparent swaps are
deprecated, so every quote (indicative and firm) now requests a confidential intent. No changes to the client flow.

**Docs:** https://docs.near-intents.org/integration/distribution-channels/1click-api/quickstart/confidential-swaps

Resolves https://github.com/brave/gate3/issues/310

### Testing

Fetched live quotes against Near Intents API, ensured every response validated through `NearIntentsQuoteResponse` struct and echoes `confidentiality: basic`.

### Proving confidentiality

I did a **`0.05 SOL -> PENGU`** swap with basic confidentiality turned on. Here is the trail:

**Solana (fully public, normal transactions):**
- [Deposit transaction - 0.05 SOL in](https://explorer.solana.com/tx/4bwpZuv1UrLtxhbVdQYinDbWeCQ4iKSR2rxNkKqgNPgD1YGEuVf2dJ6vhsLu5SVBQCenDe1NJ2tWq7iBJpUKYRGq)
- [Payout transaction - 616.9 PENGU out](https://explorer.solana.com/tx/5EEWQtRkuTi2YpxC2vCfdXLP6LSrxr8LJ5sVoZefJhSAyabmux6xShPY1m4Y2s8YTw2rMLqn3YxNZygJPRawoC6p)

**NEAR (where the swap actually settled):**
- [Bridge-in of the deposit](https://nearblocks.io/txns/8CGG9RHUa9NY6P1bihV9nvxFpZWTkFZiEd1ZbTPEXRhb)
- [Settlement leg 1 - transfer of the SOL between anonymous hex accounts](https://nearblocks.io/txns/5F57BV8N6EJyKRUUSwWc5eF4BZYtbkjs3sndmokFN9Jm)
- [Settlement leg 2 - solver moves funds](https://nearblocks.io/txns/3ACpEqk9aVpVTasvgNRfjGQY4sz8W4i8qdiPvZua133R)
- [Settlement leg 3 - the actual trade and PENGU withdrawal](https://nearblocks.io/txns/9oA9q9yc8mCJrh6h8ixHVGHAfk7rdog69q8LCwjFzYLx)

**The confidential part:** on the NEAR side, the Solana address appears nowhere. 